### PR TITLE
Disable action bar home button on main activity

### DIFF
--- a/app/src/main/java/com/daviancorp/android/ui/general/HomeActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/HomeActivity.java
@@ -15,6 +15,8 @@ public class HomeActivity extends GenericActivity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		getActionBar().setDisplayHomeAsUpEnabled(false);
+		getActionBar().setHomeButtonEnabled(false);
 		setTitle(R.string.app_name);
 
 	}


### PR DESCRIPTION
Tidies up the UI slightly by removing the back arrow from the top level activity and prevents the display from flickering or "looping" when the home button is spammed.