### PR TITLE
DisableActivities

### DIFF
--- a/app/src/main/java/com/daviancorp/android/ui/adapter/ItemDetailPagerAdapter.java
+++ b/app/src/main/java/com/daviancorp/android/ui/adapter/ItemDetailPagerAdapter.java
@@ -39,9 +39,10 @@ public class ItemDetailPagerAdapter extends FragmentPagerAdapter {
 		case 4:
 			// Location drops; gathering
 			return ItemLocationFragment.newInstance(itemId);
-		case 5:
-			// ArenaQuest rewards
-			return ItemArenaFragment.newInstance(itemId);
+//		case 5:
+//			// ArenaQuest rewards
+//            //TODO reenable when arena quests are complete.
+//			return ItemArenaFragment.newInstance(itemId);
 		default:
 			return null;
 		}
@@ -50,7 +51,7 @@ public class ItemDetailPagerAdapter extends FragmentPagerAdapter {
 	@Override
 	public int getCount() {
 		// get item count - equal to number of tabs
-		return 6;
+		return 5;
 	}
 
 }

--- a/app/src/main/java/com/daviancorp/android/ui/adapter/QuestExpandableListPagerAdapter.java
+++ b/app/src/main/java/com/daviancorp/android/ui/adapter/QuestExpandableListPagerAdapter.java
@@ -22,9 +22,10 @@ public class QuestExpandableListPagerAdapter extends FragmentPagerAdapter {
 		case 1:
 			// Port Quests
 			return QuestExpandableListFragment.newInstance("Port");
-		case 2:
-			// DLC Quests
-			return QuestExpandableListFragment.newInstance("DLC");
+//		case 2:
+//			// DLC Quests
+//            //TODO reenable when DLC quests are complete.
+//			return QuestExpandableListFragment.newInstance("DLC");
 		default:
 			return null;
 		}
@@ -33,7 +34,7 @@ public class QuestExpandableListPagerAdapter extends FragmentPagerAdapter {
 	@Override
 	public int getCount() {
 		// get item count - equal to number of tabs
-		return 3;
+		return 2;
 	}
 
 }

--- a/app/src/main/java/com/daviancorp/android/ui/adapter/SkillTreeDetailPagerAdapter.java
+++ b/app/src/main/java/com/daviancorp/android/ui/adapter/SkillTreeDetailPagerAdapter.java
@@ -45,10 +45,11 @@ public class SkillTreeDetailPagerAdapter extends FragmentPagerAdapter {
 			// List of "Legs" Armor with the SkillTree
 			return SkillTreeArmorFragment.newInstance(skillTreeId,  
 					ItemToSkillTreeListCursorLoader.TYPE_LEGS);
-		case 6:
-			// List of Decoration with the SkillTree
-			return SkillTreeDecorationFragment.newInstance(skillTreeId,  
-					ItemToSkillTreeListCursorLoader.TYPE_DECORATION);
+//		case 6:
+//			// List of Decoration with the SkillTree
+//            //TODO reenable when decorations are complete
+//			return SkillTreeDecorationFragment.newInstance(skillTreeId,
+//					ItemToSkillTreeListCursorLoader.TYPE_DECORATION);
 		default:
 			return null;
 		}
@@ -57,7 +58,7 @@ public class SkillTreeDetailPagerAdapter extends FragmentPagerAdapter {
 	@Override
 	public int getCount() {
 		// get item count - equal to number of tabs
-		return 7;
+		return 6;
 	}
 
 }

--- a/app/src/main/java/com/daviancorp/android/ui/detail/ItemArenaFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/ItemArenaFragment.java
@@ -78,9 +78,10 @@ public class ItemArenaFragment extends ListFragment implements
 	public void onListItemClick(ListView l, View v, int position, long id) {
 		// The id argument will be the Monster ID; CursorAdapter gives us this
 		// for free
-		Intent i = new Intent(getActivity(), ArenaQuestDetailActivity.class);
-		i.putExtra(ArenaQuestDetailActivity.EXTRA_ARENA_QUEST_ID, (long) v.getTag());
-		startActivity(i);
+        //TODO reenable when arena quests are complete.
+//		Intent i = new Intent(getActivity(), ArenaQuestDetailActivity.class);
+//		i.putExtra(ArenaQuestDetailActivity.EXTRA_ARENA_QUEST_ID, (long) v.getTag());
+//		startActivity(i);
 	}
 
 	private static class ArenaQuestRewardListCursorAdapter extends CursorAdapter {

--- a/app/src/main/java/com/daviancorp/android/ui/detail/ItemComponentFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/ItemComponentFragment.java
@@ -90,10 +90,10 @@ public class ItemComponentFragment extends ListFragment implements
 			i = new Intent(getActivity(), ArmorDetailActivity.class);
 			i.putExtra(ArmorDetailActivity.EXTRA_ARMOR_ID, tagId);
 		}
-//		else if (tagId >= S.SECTION_DECORATIONS) {
+		else if (tagId >= S.SECTION_DECORATIONS) {
 //			i = new Intent(getActivity(), DecorationDetailActivity.class); //TODO reenable when decorations are complete.
 //			i.putExtra(DecorationDetailActivity.EXTRA_DECORATION_ID, tagId);
-//		}
+		}
 		else {
 			i = new Intent(getActivity(), ItemDetailActivity.class);
 			i.putExtra(ItemDetailActivity.EXTRA_ITEM_ID, tagId);

--- a/app/src/main/java/com/daviancorp/android/ui/detail/ItemComponentFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/ItemComponentFragment.java
@@ -90,15 +90,16 @@ public class ItemComponentFragment extends ListFragment implements
 			i = new Intent(getActivity(), ArmorDetailActivity.class);
 			i.putExtra(ArmorDetailActivity.EXTRA_ARMOR_ID, tagId);
 		}
-		else if (tagId >= S.SECTION_DECORATIONS) {
-			i = new Intent(getActivity(), DecorationDetailActivity.class);
-			i.putExtra(DecorationDetailActivity.EXTRA_DECORATION_ID, tagId);
-		}
+//		else if (tagId >= S.SECTION_DECORATIONS) {
+//			i = new Intent(getActivity(), DecorationDetailActivity.class); //TODO reenable when decorations are complete.
+//			i.putExtra(DecorationDetailActivity.EXTRA_DECORATION_ID, tagId);
+//		}
 		else {
 			i = new Intent(getActivity(), ItemDetailActivity.class);
 			i.putExtra(ItemDetailActivity.EXTRA_ITEM_ID, tagId);
 		}
-		startActivity(i);
+		if(i!=null)
+            startActivity(i);
 	}
 
 	@Override

--- a/app/src/main/java/com/daviancorp/android/ui/detail/ItemDetailActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/ItemDetailActivity.java
@@ -23,7 +23,9 @@ public class ItemDetailActivity extends GenericTabActivity implements
 	private ActionBar actionBar;
 
 	// Tab titles
-	private String[] tabs = { "Detail", "Usage", "Monster", "Quest", "Location", "Arena"};
+    //TODO reenable when Arena Quests are complete.
+//	private String[] tabs = { "Detail", "Usage", "Monster", "Quest", "Location", "Arena"};
+    private String[] tabs = { "Detail", "Usage", "Monster", "Quest", "Location"};
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/daviancorp/android/ui/detail/SkillTreeDecorationFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/SkillTreeDecorationFragment.java
@@ -58,10 +58,11 @@ public class SkillTreeDecorationFragment extends ListFragment implements
 	public void onListItemClick(ListView l, View v, int position, long id) {
 		// The id argument will be the Item ID; CursorAdapter gives us this
 		// for free
-		
-		Intent i = new Intent(getActivity(), DecorationDetailActivity.class);
-		i.putExtra(DecorationDetailActivity.EXTRA_DECORATION_ID, (long) v.getTag());
-		startActivity(i);
+
+        //TODO reenable when decorations are complete.
+//		Intent i = new Intent(getActivity(), DecorationDetailActivity.class);
+//		i.putExtra(DecorationDetailActivity.EXTRA_DECORATION_ID, (long) v.getTag());
+//		startActivity(i);
 	}
 
 

--- a/app/src/main/java/com/daviancorp/android/ui/detail/SkillTreeDetailActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/SkillTreeDetailActivity.java
@@ -23,7 +23,9 @@ public class SkillTreeDetailActivity extends GenericTabActivity implements
 	private ActionBar actionBar;
 
 	// Tab titles
-	private String[] tabs = { "Detail" , "Head" , "Body" , "Arm" , "Waist", "Leg" , "Jewels" };
+    //TODO reenable when decorations are finished
+//	private String[] tabs = { "Detail" , "Head" , "Body" , "Arm" , "Waist", "Leg" , "Jewels" };
+    private String[] tabs = { "Detail" , "Head" , "Body" , "Arm" , "Waist", "Leg"};
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/daviancorp/android/ui/detail/WishlistDataDetailFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/WishlistDataDetailFragment.java
@@ -255,10 +255,10 @@ public class WishlistDataDetailFragment extends SherlockListFragment implements
 				i = new Intent(getActivity(), ItemDetailActivity.class);
 				i.putExtra(ItemDetailActivity.EXTRA_ITEM_ID, mId);
 			}
-			else if (mId < S.SECTION_ARMOR) {
-				i = new Intent(getActivity(), DecorationDetailActivity.class);
-				i.putExtra(DecorationDetailActivity.EXTRA_DECORATION_ID, mId);
-			}
+//			else if (mId < S.SECTION_ARMOR) {
+//				i = new Intent(getActivity(), DecorationDetailActivity.class);
+//				i.putExtra(DecorationDetailActivity.EXTRA_DECORATION_ID, mId); //TODO reenable when decorations are complete.
+//			}
 			else if (mId < S.SECTION_WEAPON) {
 				i = new Intent(getActivity(), ArmorDetailActivity.class);
 				i.putExtra(ArmorDetailActivity.EXTRA_ARMOR_ID, mId);

--- a/app/src/main/java/com/daviancorp/android/ui/general/HomeFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/HomeFragment.java
@@ -62,11 +62,11 @@ public class HomeFragment extends Fragment {
 		mQuests = (TextView) v.findViewById(R.id.quests);
 		mItems = (TextView) v.findViewById(R.id.items);
 		mCombining = (TextView) v.findViewById(R.id.combining);
-		mDecorations = (TextView) v.findViewById(R.id.decorations);
+		//mDecorations = (TextView) v.findViewById(R.id.decorations); // Disabled
 		mSkillTrees = (TextView) v.findViewById(R.id.skilltrees);
 		mLocations = (TextView) v.findViewById(R.id.locations);
-		mHuntingFleet = (TextView) v.findViewById(R.id.hunting_fleet);
-		mArenaQuests = (TextView) v.findViewById(R.id.arena_quests);
+		//mHuntingFleet = (TextView) v.findViewById(R.id.hunting_fleet); // Disabled
+		//mArenaQuests = (TextView) v.findViewById(R.id.arena_quests); // Disabled
 		mWishlists = (TextView) v.findViewById(R.id.wishlists);
 
 		mMonsters.setOnClickListener(new OnClickListener() {
@@ -117,13 +117,13 @@ public class HomeFragment extends Fragment {
 			}
 		});
 
-		mDecorations.setOnClickListener(new OnClickListener() {
-			@Override
-			public void onClick(View v) {
-				Intent intent = new Intent(getActivity(), DecorationListActivity.class);
-				startActivity(intent);
-			}
-		});
+//		mDecorations.setOnClickListener(new OnClickListener() {
+//			@Override
+//			public void onClick(View v) {
+//				Intent intent = new Intent(getActivity(), DecorationListActivity.class);
+//				startActivity(intent);
+//			}
+//		});
 
 		mSkillTrees.setOnClickListener(new OnClickListener() {
 			@Override
@@ -141,21 +141,21 @@ public class HomeFragment extends Fragment {
 			}
 		});
 
-		mHuntingFleet.setOnClickListener(new OnClickListener() {
-			@Override
-			public void onClick(View v) {
-				Intent intent = new Intent(getActivity(), HuntingFleetListActivity.class);
-				startActivity(intent);
-			}
-		});
+//		mHuntingFleet.setOnClickListener(new OnClickListener() {
+//			@Override
+//			public void onClick(View v) {
+//				Intent intent = new Intent(getActivity(), HuntingFleetListActivity.class);
+//				startActivity(intent);
+//			}
+//		});
 
-		mArenaQuests.setOnClickListener(new OnClickListener() {
-			@Override
-			public void onClick(View v) {
-				Intent intent = new Intent(getActivity(), ArenaQuestListActivity.class);
-				startActivity(intent);
-			}
-		});
+//		mArenaQuests.setOnClickListener(new OnClickListener() {
+//			@Override
+//			public void onClick(View v) {
+//				Intent intent = new Intent(getActivity(), ArenaQuestListActivity.class);
+//				startActivity(intent);
+//			}
+//		});
 
 		mWishlists.setOnClickListener(new OnClickListener() {
 			@Override

--- a/app/src/main/java/com/daviancorp/android/ui/list/ArenaQuestListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/ArenaQuestListFragment.java
@@ -55,6 +55,7 @@ public class ArenaQuestListFragment extends ListFragment implements
 	@Override
 	public void onListItemClick(ListView l, View v, int position, long id) {
 		// The id argument will be the Arena Quest ID; CursorAdapter gives us this for free
+        //TODO reenable when Arena quests are complete. Don't need to disable this because its recursive.
 		Intent i = new Intent(getActivity(), ArenaQuestDetailActivity.class);
 		i.putExtra(ArenaQuestDetailActivity.EXTRA_ARENA_QUEST_ID, id);
 		startActivity(i);

--- a/app/src/main/java/com/daviancorp/android/ui/list/DecorationListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/DecorationListFragment.java
@@ -100,9 +100,11 @@ public class DecorationListFragment extends ListFragment implements
 	public void onListItemClick(ListView l, View v, int position, long id) {
 		// The id argument will be the Monster ID; CursorAdapter gives us this
 		// for free
-		Intent i = new Intent(getActivity(), DecorationDetailActivity.class);
-		i.putExtra(DecorationDetailActivity.EXTRA_DECORATION_ID, (long) v.getTag());
-		startActivity(i);
+
+        //TODO reenable when decorations are complete.
+//		Intent i = new Intent(getActivity(), DecorationDetailActivity.class);
+//		i.putExtra(DecorationDetailActivity.EXTRA_DECORATION_ID, (long) v.getTag());
+//		startActivity(i);
 	}
 	
 

--- a/app/src/main/java/com/daviancorp/android/ui/list/QuestListActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/QuestListActivity.java
@@ -21,10 +21,14 @@ public class QuestListActivity extends GenericTabActivity implements
 	private ActionBar actionBar;
 
 	// Tab titles
-	private String[] tabs = { 
-			QuestListCursorLoader.HUB_VILLAGE, 
-			QuestListCursorLoader.HUB_PORT, 
-			QuestListCursorLoader.HUB_DLC };
+    // TODO reenable when dlc quests are complete
+//	private String[] tabs = {
+//			QuestListCursorLoader.HUB_VILLAGE,
+//			QuestListCursorLoader.HUB_PORT,
+//			QuestListCursorLoader.HUB_DLC };
+    private String[] tabs = {
+			QuestListCursorLoader.HUB_VILLAGE,
+			QuestListCursorLoader.HUB_PORT};
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -107,36 +107,6 @@
             android:textSize="20sp" />
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight=".1"
-        android:orientation="horizontal" >
-
-        <TextView
-            android:id="@+id/decorations"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight=".5"
-            android:background="@drawable/weapon_clicked_states"
-            android:layout_margin="2dp"
-            android:gravity="center"
-            android:text="@string/decorations"
-            android:textColor="@color/white"
-            android:textSize="20sp" />
-
-        <TextView
-            android:id="@+id/skilltrees"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight=".5"
-            android:background="@drawable/weapon_clicked_states"
-            android:layout_margin="2dp"
-            android:gravity="center"
-            android:text="@string/skill_trees"
-            android:textColor="@color/white"
-            android:textSize="20sp" />
-    </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -157,37 +127,6 @@
             android:textSize="20sp" />
 
         <TextView
-            android:id="@+id/hunting_fleet"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight=".5"
-            android:background="@drawable/weapon_clicked_states"
-            android:layout_margin="2dp"
-            android:gravity="center"
-            android:text="@string/hunting_fleet"
-            android:textColor="@color/white"
-            android:textSize="20sp" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight=".1"
-        android:orientation="horizontal" >
-
-        <TextView
-            android:id="@+id/arena_quests"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight=".5"
-            android:background="@drawable/weapon_clicked_states"
-            android:layout_margin="2dp"
-            android:gravity="center"
-            android:text="@string/arena_quests"
-            android:textColor="@color/white"
-            android:textSize="20sp" />
-
-        <TextView
             android:id="@+id/wishlists"
             android:layout_width="0dp"
             android:layout_height="match_parent"
@@ -198,6 +137,78 @@
             android:text="@string/wishlist"
             android:textColor="@color/white"
             android:textSize="20sp" />
+
     </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight=".1"
+        android:orientation="horizontal" >
+
+        <TextView
+            android:id="@+id/skilltrees"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight=".5"
+            android:background="@drawable/weapon_clicked_states"
+            android:layout_margin="2dp"
+            android:gravity="center"
+            android:text="@string/skill_trees"
+            android:textColor="@color/white"
+            android:textSize="20sp" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight=".5"
+            android:layout_margin="2dp"
+            />
+    </LinearLayout>
+
+    <!--<LinearLayout-->
+        <!--android:layout_width="match_parent"-->
+        <!--android:layout_height="0dp"-->
+        <!--android:layout_weight=".1"-->
+        <!--android:orientation="horizontal" >-->
+
+        <!--<TextView-->
+            <!--android:id="@+id/arena_quests"-->
+            <!--android:layout_width="0dp"-->
+            <!--android:layout_height="match_parent"-->
+            <!--android:layout_weight=".5"-->
+            <!--android:background="@drawable/weapon_clicked_states"-->
+            <!--android:layout_margin="2dp"-->
+            <!--android:gravity="center"-->
+            <!--android:text="@string/arena_quests"-->
+            <!--android:textColor="@color/white"-->
+            <!--android:textSize="20sp" />-->
+
+        <!--<TextView-->
+            <!--android:id="@+id/hunting_fleet"-->
+            <!--android:layout_width="0dp"-->
+            <!--android:layout_height="match_parent"-->
+            <!--android:layout_weight=".5"-->
+            <!--android:background="@drawable/weapon_clicked_states"-->
+            <!--android:layout_margin="2dp"-->
+            <!--android:gravity="center"-->
+            <!--android:text="@string/hunting_fleet"-->
+            <!--android:textColor="@color/white"-->
+            <!--android:textSize="20sp" />-->
+
+        <!--<TextView-->
+            <!--android:id="@+id/decorations"-->
+            <!--android:layout_width="0dp"-->
+            <!--android:layout_height="match_parent"-->
+            <!--android:layout_weight=".5"-->
+            <!--android:background="@drawable/weapon_clicked_states"-->
+            <!--android:layout_margin="2dp"-->
+            <!--android:gravity="center"-->
+            <!--android:text="@string/decorations"-->
+            <!--android:textColor="@color/white"-->
+            <!--android:textSize="20sp" />-->
+
+
+    <!--</LinearLayout>-->
 
 </LinearLayout>


### PR DESCRIPTION
Disabled the following features: 
Hunting Fleet
Arena Quests
DLC Quests (tab)
Decorations

I tried to hunt down and comment out all the ways into each of these activities and leave TODO tags so we can find them later.

The main menu looks fine now and buttons can be easily re-enabled.