### PR TITLE
Fixed text wrapping on skill descriptions

### DIFF
--- a/app/src/main/java/com/daviancorp/android/ui/list/WeaponBladeListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WeaponBladeListFragment.java
@@ -241,7 +241,7 @@ public class WeaponBladeListFragment extends WeaponListFragment implements
 				specialtv.setText(special);
 				specialtv.setGravity(Gravity.CENTER);
 			}
-			if (type.equals("Switch Axe")) {
+			if (type.equals("Switch Axe") || type.equals("Charge Blade")) {
 				String special = weapon.getPhial();
 				specialtv.setText(special);
 				specialtv.setGravity(Gravity.CENTER);

--- a/app/src/main/java/com/daviancorp/android/ui/list/WeaponBowListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WeaponBowListFragment.java
@@ -106,7 +106,7 @@ public class WeaponBowListFragment extends WeaponListFragment implements
 
             for(int i = 0; i < weapon.getTree_Depth(); i++)
             {
-                name = name + " ";
+                name = name + "-";
             }
 			
 			name = name + weapon.getName();

--- a/app/src/main/java/com/daviancorp/android/ui/list/WeaponBowgunListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WeaponBowgunListFragment.java
@@ -98,7 +98,7 @@ public class WeaponBowgunListFragment extends WeaponListFragment implements
 
             for(int i = 0; i < weapon.getTree_Depth(); i++)
             {
-                name = name + " ";
+                name = name + "-";
             }
 			
 			name = name + weapon.getName();

--- a/app/src/main/res/layout/fragment_skill_detail_listitem.xml
+++ b/app/src/main/res/layout/fragment_skill_detail_listitem.xml
@@ -2,13 +2,13 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/listitem"
     android:layout_width="match_parent"
-    android:layout_height="35dp"
+    android:layout_height="wrap_content"
     android:orientation="horizontal" >
 
     <TextView
         android:id="@+id/skill"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="35dip"
         android:layout_weight=".3"
         android:gravity="center|center_vertical"
         android:textStyle="bold"


### PR DESCRIPTION
Mislabeled the commit, sorry. Fixed wrapping on skill description text, I had improperly set a minimum height for the fields and accidentally made that constant so it was cutting off longer descriptions.