### PR TITLE
Navigation Drawer

### DIFF
--- a/app/src/main/java/com/daviancorp/android/ui/detail/ItemDetailActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/ItemDetailActivity.java
@@ -30,7 +30,6 @@ public class ItemDetailActivity extends GenericTabActivity implements
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		
 		long id = getIntent().getLongExtra(EXTRA_ITEM_ID, -1);
 		setTitle(DataManager.get(getApplicationContext()).getItem(id).getName());
 

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.NavUtils;
+import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.text.Spannable;
@@ -102,6 +103,7 @@ public class GenericActionBarActivity extends ActionBarActivity {
                         break;
                 }
                 startActivity(intent);
+                mDrawerLayout.closeDrawers();
             }
         });
         mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close){
@@ -159,10 +161,7 @@ public class GenericActionBarActivity extends ActionBarActivity {
         switch (item.getItemId()) {
             case android.R.id.home:
                 // TODO For the love of god fix this. Proper back navigation goes here I think.
-                // Whenever the home button is pressed, go back to home and clear the stack of activities
-//                Intent intent = new Intent(GenericActionBarActivity.this, HomeActivity.class);
-//                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-//                startActivity(intent);
+                super.onBackPressed(); // Emulate back button when up is pressed. This isn't ideal and kind of hackey.
                 return true;
             case R.id.about:
                 FragmentManager fm = getSupportFragmentManager();
@@ -201,6 +200,16 @@ public class GenericActionBarActivity extends ActionBarActivity {
             mi.setTitle(newTitle);
         }
         return true;
+    }
+
+    public void onBackPressed(){
+        // If back is pressed while drawer is open, close drawer.
+        if(mDrawerLayout.isDrawerOpen(GravityCompat.START)){
+            mDrawerLayout.closeDrawers();
+        }
+        else{
+            super.onBackPressed();
+        }
     }
 
     public Fragment getDetail() {

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
@@ -1,0 +1,209 @@
+package com.daviancorp.android.ui.general;
+
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.NavUtils;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBarDrawerToggle;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
+
+import android.support.v7.app.ActionBarActivity;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+
+import com.daviancorp.android.mh4udatabase.R;
+import com.daviancorp.android.ui.dialog.AboutDialogFragment;
+import com.daviancorp.android.ui.list.ArmorListActivity;
+import com.daviancorp.android.ui.list.CombiningListActivity;
+import com.daviancorp.android.ui.list.DecorationListActivity;
+import com.daviancorp.android.ui.list.ItemListActivity;
+import com.daviancorp.android.ui.list.LocationGridActivity;
+import com.daviancorp.android.ui.list.MonsterGridActivity;
+import com.daviancorp.android.ui.list.QuestListActivity;
+import com.daviancorp.android.ui.list.SkillTreeListActivity;
+import com.daviancorp.android.ui.list.WeaponGridActivity;
+import com.daviancorp.android.ui.list.WishlistListActivity;
+
+/*
+ * Any subclass needs to:
+ *  - override onCreate() to set title
+ *  - override createFragment() for detail fragments
+ */
+
+public class GenericActionBarActivity extends ActionBarActivity {
+
+    protected static final String DIALOG_ABOUT = "about";
+
+    protected Fragment detail;
+    private ListView mDrawerList;
+    private ArrayAdapter<String> mDrawerAdapter;
+    public ActionBarDrawerToggle mDrawerToggle;
+    public DrawerLayout mDrawerLayout;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        //setupDrawer();
+    }
+
+    // Set up drawer toggle actions
+    public void setupDrawer(){
+        mDrawerLayout = (DrawerLayout)findViewById(R.id.drawer_layout);
+        // Populate navigation drawer
+        mDrawerList = (ListView)findViewById(R.id.navList);
+        addDrawerItems();
+        mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                // Set navigation actions
+                Intent intent = new Intent();
+
+                switch (position){
+                    case 0: // Monsters
+                        intent = new Intent(getApplicationContext(),MonsterGridActivity.class);
+                        break;
+                    case 1: // Weapons
+                        intent = new Intent(getApplicationContext(), WeaponGridActivity.class);
+                        break;
+                    case 2: // Armor
+                        intent = new Intent(getApplicationContext(), ArmorListActivity.class);
+                        break;
+                    case 3: // Quests
+                        intent = new Intent(getApplicationContext(), QuestListActivity.class);
+                        break;
+                    case 4: // Items
+                        intent = new Intent(getApplicationContext(), ItemListActivity.class);
+                        break;
+                    case 5: // Combining
+                        intent = new Intent(getApplicationContext(), CombiningListActivity.class);
+                        break;
+                    case 6: // Locations
+                        intent = new Intent(getApplicationContext(), LocationGridActivity.class);
+                        break;
+                    case 7: // Decorations
+                        intent = new Intent(getApplicationContext(), DecorationListActivity.class);
+                        break;
+                    case 8: // Skill Trees
+                        intent = new Intent(getApplicationContext(), SkillTreeListActivity.class);
+                        break;
+                    case 9: // Wishlists
+                        intent = new Intent(getApplicationContext(), WishlistListActivity.class);
+                        break;
+                }
+                startActivity(intent);
+            }
+        });
+        mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close){
+            /** Called when a drawer has settled in a completely open state. */
+            public void onDrawerOpened(View drawerView){
+                super.onDrawerOpened(drawerView);
+                invalidateOptionsMenu(); // Creates call to onPrepareOptionsMenu()
+            }
+            /** Called when a drawer has settled in a completely closed state. */
+            public void onDrawerClosed(View view){
+                super.onDrawerClosed(view);
+                invalidateOptionsMenu(); // Creates call to onPrepareOptionsMenu()
+            }
+        };
+
+        // Enable menu button to toggle drawer
+        mDrawerToggle.setDrawerIndicatorEnabled(false);
+        mDrawerLayout.setDrawerListener(mDrawerToggle);
+    }
+
+    // Set up drawer menu options
+    private void addDrawerItems(){
+        String[] menuArray = getResources().getStringArray(R.array.drawer_items);
+        mDrawerAdapter = new ArrayAdapter<>(getApplicationContext(), android.R.layout.simple_list_item_1, menuArray);
+        mDrawerList.setAdapter(mDrawerAdapter);
+    }
+
+    public void enableDrawerIndicator(){
+        mDrawerToggle.setDrawerIndicatorEnabled(true);
+    }
+
+    // Sync button animation sync with drawer state
+    @Override
+    protected void onPostCreate(Bundle savedInstanceState){
+        super.onPostCreate(savedInstanceState);
+        mDrawerToggle.syncState();
+    }
+
+    // Handle toggle state sync across configuration changes (rotation)
+    @Override
+    public void onConfigurationChanged(Configuration newConfig){
+        super.onConfigurationChanged(newConfig);
+        mDrawerToggle.onConfigurationChanged(newConfig);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+
+        // Detect navigation drawer item selected
+        if(mDrawerToggle.onOptionsItemSelected(item)){
+            return true;
+        }
+
+        // Detect home and or expansion menu item selections
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                // TODO For the love of god fix this. Proper back navigation goes here I think.
+                // Whenever the home button is pressed, go back to home and clear the stack of activities
+//                Intent intent = new Intent(GenericActionBarActivity.this, HomeActivity.class);
+//                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+//                startActivity(intent);
+                return true;
+            case R.id.about:
+                FragmentManager fm = getSupportFragmentManager();
+                AboutDialogFragment dialog = new AboutDialogFragment();
+                dialog.show(fm, DIALOG_ABOUT);
+                return true;
+
+            case R.id.send_feedback:
+                Intent email = new Intent(Intent.ACTION_SEND);
+                email.setType("text/email");
+                email.putExtra(Intent.EXTRA_EMAIL, new String[]{"monster-hunter-database-feedback@googlegroups.com"});
+                email.putExtra(Intent.EXTRA_SUBJECT, "MH4U Database Feedback");
+                startActivity(Intent.createChooser(email, "Send Feedback:"));
+
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.main, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        for (int i = 0; i < menu.size(); i++) {
+            MenuItem mi = menu.getItem(i);
+            String title = mi.getTitle().toString();
+            Spannable newTitle = new SpannableString(title);
+            newTitle.setSpan(new ForegroundColorSpan(Color.WHITE), 0,
+                    newTitle.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+            mi.setTitle(newTitle);
+        }
+        return true;
+    }
+
+    public Fragment getDetail() {
+        return detail;
+    }
+}

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericActivity.java
@@ -33,156 +33,26 @@ import com.daviancorp.android.ui.dialog.AboutDialogFragment;
  *  - override createFragment() for detail fragments
  */
 
-public abstract class GenericActivity extends ActionBarActivity {
-
-	protected static final String DIALOG_ABOUT = "about";
-
-	protected Fragment detail;
-    private ListView mDrawerList;
-    private ArrayAdapter<String> mAdapter;
-    public ActionBarDrawerToggle mDrawerToggle;
-    public DrawerLayout mDrawerLayout;
+public abstract class GenericActivity extends GenericActionBarActivity {
 
 	protected abstract Fragment createFragment();
-	
-	@Override
-	public void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		setContentView(R.layout.activity_main);
 
-        mDrawerLayout = (DrawerLayout)findViewById(R.id.drawer_layout);
-        // Populate navigation drawer
-        mDrawerList = (ListView)findViewById(R.id.navList);
-        addDrawerItems();
-        mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Set navigation actions
-                //
-                //
-                //
-                //
-            }
-        });
-        setupDrawer();
-
-		FragmentManager fm = getSupportFragmentManager();
-		Fragment fragment = fm.findFragmentById(R.id.fragment_container);
-
-		if (fragment == null) {
-			fragment = createFragment();
-			fm.beginTransaction().add(R.id.fragment_container, fragment)
-					.commit();
-		}
-		
-		setTitle(R.string.app_name);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-		getSupportActionBar().setHomeButtonEnabled(true);
-	}
-
-    // Set up drawer menu options
-    private void addDrawerItems(){
-        String[] menuArray = getResources().getStringArray(R.array.drawer_items);
-        mAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, menuArray);
-        mDrawerList.setAdapter(mAdapter);
-    }
-
-
-    // Set up drawer toggle actions
-    private void setupDrawer(){
-        mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close){
-            /** Called when a drawer has settled in a completely open state. */
-            public void onDrawerOpened(View drawerView){
-                super.onDrawerOpened(drawerView);
-                invalidateOptionsMenu(); // Creates call to onPrepareOptionsMenu()
-            }
-            /** Called when a drawer has settled in a completely closed state. */
-            public void onDrawerClosed(View view){
-                super.onDrawerClosed(view);
-                invalidateOptionsMenu(); // Creates call to onPrepareOptionsMenu()
-            }
-        };
-
-        // Enable menu button to toggle drawer
-        mDrawerToggle.setDrawerIndicatorEnabled(false);
-        mDrawerLayout.setDrawerListener(mDrawerToggle);
-    }
-
-    public void enableDrawerIndicator(){
-        mDrawerToggle.setDrawerIndicatorEnabled(true);
-    }
-
-    // Sync button animation sync with drawer state
     @Override
-    protected void onPostCreate(Bundle savedInstanceState){
-        super.onPostCreate(savedInstanceState);
-        mDrawerToggle.syncState();
-    }
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        super.setupDrawer(); // Needs to be called after setContentView
+        FragmentManager fm = getSupportFragmentManager();
+        Fragment fragment = fm.findFragmentById(R.id.fragment_container);
 
-    // Handle toggle state sync across configuration changes (rotation)
-    @Override
-    public void onConfigurationChanged(Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        mDrawerToggle.onConfigurationChanged(newConfig);
-    }
-
-	@Override
-	public boolean onOptionsItemSelected(MenuItem item) {
-
-        // Detect navigation drawer item selected
-        if(mDrawerToggle.onOptionsItemSelected(item)){
-            return true;
+        if (fragment == null) {
+            fragment = createFragment();
+            fm.beginTransaction().add(R.id.fragment_container, fragment)
+                    .commit();
         }
 
-        // Detect home and or expansion menu item selections
-		switch (item.getItemId()) {
-		case android.R.id.home:
-            // For the love of god fix this
-			// Whenever the home button is pressed, go back to home and clear the stack of activities
-			Intent intent = new Intent(GenericActivity.this, HomeActivity.class);
-			intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-			startActivity(intent);
-			return true;
-		case R.id.about:
-			FragmentManager fm = getSupportFragmentManager();
-			AboutDialogFragment dialog = new AboutDialogFragment();
-			dialog.show(fm, DIALOG_ABOUT);
-			return true;
-
-        case R.id.send_feedback:
-            Intent email = new Intent(Intent.ACTION_SEND);
-            email.setType("text/email");
-            email.putExtra(Intent.EXTRA_EMAIL, new String[]{"monster-hunter-database-feedback@googlegroups.com"});
-            email.putExtra(Intent.EXTRA_SUBJECT, "MH4U Database Feedback");
-            startActivity(Intent.createChooser(email, "Send Feedback:"));
-
-		default:
-			return super.onOptionsItemSelected(item);
-		}
-	}
-
-	@Override
-	public boolean onCreateOptionsMenu(Menu menu) {
-		super.onCreateOptionsMenu(menu);
-		MenuInflater inflater = getMenuInflater();
-		inflater.inflate(R.menu.main, menu);
-		return true;
-	}
-
-	@Override
-	public boolean onPrepareOptionsMenu(Menu menu) {
-		for (int i = 0; i < menu.size(); i++) {
-			MenuItem mi = menu.getItem(i);
-			String title = mi.getTitle().toString();
-			Spannable newTitle = new SpannableString(title);
-			newTitle.setSpan(new ForegroundColorSpan(Color.WHITE), 0,
-					newTitle.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-			mi.setTitle(newTitle);
-		}
-		return true;
-	}
-
-	public Fragment getDetail() {
-		return detail;
-	}
+        setTitle(R.string.app_name);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setHomeButtonEnabled(true);
+    }
 }

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericActivity.java
@@ -1,10 +1,15 @@
 package com.daviancorp.android.ui.general;
 
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.widget.DrawerLayout;
+import android.support.v7.app.ActionBarDrawerToggle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
@@ -13,6 +18,12 @@ import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.Toolbar;
+
 import com.daviancorp.android.mh4udatabase.R;
 import com.daviancorp.android.ui.dialog.AboutDialogFragment;
 
@@ -27,6 +38,10 @@ public abstract class GenericActivity extends ActionBarActivity {
 	protected static final String DIALOG_ABOUT = "about";
 
 	protected Fragment detail;
+    private ListView mDrawerList;
+    private ArrayAdapter<String> mAdapter;
+    public ActionBarDrawerToggle mDrawerToggle;
+    public DrawerLayout mDrawerLayout;
 
 	protected abstract Fragment createFragment();
 	
@@ -34,6 +49,22 @@ public abstract class GenericActivity extends ActionBarActivity {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_main);
+
+        mDrawerLayout = (DrawerLayout)findViewById(R.id.drawer_layout);
+        // Populate navigation drawer
+        mDrawerList = (ListView)findViewById(R.id.navList);
+        addDrawerItems();
+        mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                // Set navigation actions
+                //
+                //
+                //
+                //
+            }
+        });
+        setupDrawer();
 
 		FragmentManager fm = getSupportFragmentManager();
 		Fragment fragment = fm.findFragmentById(R.id.fragment_container);
@@ -49,11 +80,64 @@ public abstract class GenericActivity extends ActionBarActivity {
 		getSupportActionBar().setHomeButtonEnabled(true);
 	}
 
+    // Set up drawer menu options
+    private void addDrawerItems(){
+        String[] menuArray = getResources().getStringArray(R.array.drawer_items);
+        mAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, menuArray);
+        mDrawerList.setAdapter(mAdapter);
+    }
+
+
+    // Set up drawer toggle actions
+    private void setupDrawer(){
+        mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close){
+            /** Called when a drawer has settled in a completely open state. */
+            public void onDrawerOpened(View drawerView){
+                super.onDrawerOpened(drawerView);
+                invalidateOptionsMenu(); // Creates call to onPrepareOptionsMenu()
+            }
+            /** Called when a drawer has settled in a completely closed state. */
+            public void onDrawerClosed(View view){
+                super.onDrawerClosed(view);
+                invalidateOptionsMenu(); // Creates call to onPrepareOptionsMenu()
+            }
+        };
+
+        // Enable menu button to toggle drawer
+        mDrawerToggle.setDrawerIndicatorEnabled(false);
+        mDrawerLayout.setDrawerListener(mDrawerToggle);
+    }
+
+    public void enableDrawerIndicator(){
+        mDrawerToggle.setDrawerIndicatorEnabled(true);
+    }
+
+    // Sync button animation sync with drawer state
+    @Override
+    protected void onPostCreate(Bundle savedInstanceState){
+        super.onPostCreate(savedInstanceState);
+        mDrawerToggle.syncState();
+    }
+
+    // Handle toggle state sync across configuration changes (rotation)
+    @Override
+    public void onConfigurationChanged(Configuration newConfig){
+        super.onConfigurationChanged(newConfig);
+        mDrawerToggle.onConfigurationChanged(newConfig);
+    }
 
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
+
+        // Detect navigation drawer item selected
+        if(mDrawerToggle.onOptionsItemSelected(item)){
+            return true;
+        }
+
+        // Detect home and or expansion menu item selections
 		switch (item.getItemId()) {
 		case android.R.id.home:
+            // For the love of god fix this
 			// Whenever the home button is pressed, go back to home and clear the stack of activities
 			Intent intent = new Intent(GenericActivity.this, HomeActivity.class);
 			intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericTabActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericTabActivity.java
@@ -24,9 +24,7 @@ import com.daviancorp.android.ui.dialog.AboutDialogFragment;
  *  - override onCreate() to set title
  */
 
-public abstract class GenericTabActivity extends ActionBarActivity{
-
-	protected static final String DIALOG_ABOUT = "about";
+public abstract class GenericTabActivity extends GenericActionBarActivity{
 
 	protected Fragment detail;
 
@@ -40,52 +38,6 @@ public abstract class GenericTabActivity extends ActionBarActivity{
 		getSupportActionBar().setHomeButtonEnabled(true);
 
 		setContentView(R.layout.activity_tab);
-
-	}
-
-	@Override
-	public boolean onOptionsItemSelected(MenuItem item) {
-		switch (item.getItemId()) {
-		case android.R.id.home:
-			// Whenever the home button is pressed, go back to home and clear the stack of activities
-			Intent intent = new Intent(GenericTabActivity.this,
-					HomeActivity.class);
-			intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-			startActivity(intent);
-			return true;
-		case R.id.about:
-			FragmentManager fm = getSupportFragmentManager();
-			AboutDialogFragment dialog = new AboutDialogFragment();
-			dialog.show(fm, DIALOG_ABOUT);
-
-			return true;
-		default:
-			return super.onOptionsItemSelected(item);
-		}
-	}
-
-	@Override
-	public boolean onCreateOptionsMenu(Menu menu) {
-		super.onCreateOptionsMenu(menu);
-		MenuInflater inflater = new MenuInflater(getApplicationContext());
-		inflater.inflate(R.menu.main, menu);
-		return true;
-	}
-
-	@Override
-	public boolean onPrepareOptionsMenu(Menu menu) {
-		for (int i = 0; i < menu.size(); i++) {
-			MenuItem mi = menu.getItem(i);
-			String title = mi.getTitle().toString();
-			Spannable newTitle = new SpannableString(title);
-			newTitle.setSpan(new ForegroundColorSpan(Color.WHITE), 0,
-					newTitle.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-			mi.setTitle(newTitle);
-		}
-		return true;
-	}
-
-	public Fragment getDetail() {
-		return detail;
+        setupDrawer(); // Needs to be called after setContentView
 	}
 }

--- a/app/src/main/java/com/daviancorp/android/ui/general/HomeActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/HomeActivity.java
@@ -15,8 +15,9 @@ public class HomeActivity extends GenericActivity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		getSupportActionBar().setDisplayHomeAsUpEnabled(false);
-		getSupportActionBar().setHomeButtonEnabled(false);
+//		getSupportActionBar().setDisplayHomeAsUpEnabled(false);
+//		getSupportActionBar().setHomeButtonEnabled(false);
+        super.enableDrawerIndicator();
 		setTitle(R.string.app_name);
 
 	}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,7 +16,8 @@
             android:layout_width="260dp"
             android:layout_height="match_parent"
             android:layout_gravity="left|start"
-            android:background="#ffeeeeee"/>
+            android:textColor="@color/primarytextcolor"
+            android:background="@color/primarycolor"/> <!-- change this to a generic color-->
 
 
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,7 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/fragment_container"
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_below="@+id/toolbar"
+    android:id="@+id/drawer_layout"
+    android:elevation="7sp"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent">
 
-</RelativeLayout>
+        <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/fragment_container"/>
+
+        <ListView
+            android:id="@+id/navList"
+            android:layout_width="260dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="left|start"
+            android:background="#ffeeeeee"/>
+
+
+
+</android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_tab.xml
+++ b/app/src/main/res/layout/activity_tab.xml
@@ -1,12 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/fragment_container"
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_below="@+id/toolbar"
+    android:id="@+id/drawer_layout"
+    android:elevation="7sp"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent">
 
-    <android.support.v4.view.ViewPager
-        android:id="@+id/pager"
+    <RelativeLayout
+        android:id="@+id/fragment_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent" >
 
-</RelativeLayout>
+        <android.support.v4.view.ViewPager
+            android:id="@+id/pager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </RelativeLayout>
+
+    <ListView
+        android:id="@+id/navList"
+        android:layout_width="260dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="left|start"
+        android:textColor="@color/primarytextcolor"
+        android:background="@color/primarycolor"/> <!-- change this to a generic color-->
+
+</android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <android.support.v7.widget.Toolbar
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/toolbar"
+        app:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize">
+
+        </android.support.v7.widget.Toolbar>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="cancel">Cancel</string>
     <string name="submit">Submit</string>
 
+    <string name="drawer_open">Open navigation drawer</string>
+    <string name="drawer_close">Close navigation drawer</string>
     <string-array name="drawer_items">
         <item>"Monsters"</item>
         <item>"Weapons"</item>
@@ -37,11 +39,9 @@
         <item>"Quests"</item>
         <item>"Items"</item>
         <item>"Combining"</item>
+        <item>"Locations"</item>
         <item>"Decorations"</item>
         <item>"Skill Trees"</item>
-        <item>"Locations"</item>
-        <item>"Hunting Fleet"</item>
-        <item>"Arena Quests"</item>
         <item>"Wishlists"</item>
     </string-array>
 


### PR DESCRIPTION
Minimal styling right now. Drawer is available on all pages of the app except the first page of the wishlist (WishlistListFragment.java) as it doesn't use our generic xml files.

The up button now functions identically to the back button. Optimally the up button should bring us to the parent in the app hierarchy but I don't think the parent activities are established enough to do that.

![Nav Drawer on Main Menu](https://s3.amazonaws.com/pushbullet-uploads/udA5m-xkNWYlFN7L2WuYBhZkUVJKCI7T72uwFN/Screenshot_2015-02-24-00-09-24.png)
