### PR TITLE
Navdrawer behavior fixes. Creatable tags in Weapon Tree Tab

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
             android:name="com.daviancorp.android.ui.list.MonsterListActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop">
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -40,7 +40,7 @@
             android:label="@string/app_name"
             android:windowSoftInputMode="stateHidden"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
         <activity
             android:name="com.daviancorp.android.ui.detail.ItemDetailActivity"
             android:label="@string/app_name"
@@ -55,7 +55,7 @@
             android:name="com.daviancorp.android.ui.list.ArmorListActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
         <activity
             android:name="com.daviancorp.android.ui.detail.ArmorDetailActivity"
             android:label="@string/app_name"
@@ -70,7 +70,7 @@
             android:name="com.daviancorp.android.ui.list.LocationListActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
         <activity
             android:name="com.daviancorp.android.ui.detail.LocationDetailActivity"
             android:label="@string/app_name"
@@ -85,14 +85,14 @@
             android:name="com.daviancorp.android.ui.list.CombiningListActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
 
         <!-- QUEST LIST SECTION -->
         <activity
             android:name="com.daviancorp.android.ui.list.QuestListActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
         <activity
             android:name="com.daviancorp.android.ui.detail.QuestDetailActivity"
             android:label="@string/app_name"
@@ -107,7 +107,7 @@
             android:name="com.daviancorp.android.ui.list.ArenaQuestListActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
         <activity
             android:name="com.daviancorp.android.ui.detail.ArenaQuestDetailActivity"
             android:label="@string/app_name"
@@ -122,7 +122,7 @@
             android:name="com.daviancorp.android.ui.list.SkillTreeListActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
         <activity
             android:name="com.daviancorp.android.ui.detail.SkillTreeDetailActivity"
             android:label="@string/app_name"
@@ -137,7 +137,7 @@
             android:name="com.daviancorp.android.ui.list.DecorationListActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
         <activity
             android:name="com.daviancorp.android.ui.detail.DecorationDetailActivity"
             android:label="@string/app_name"
@@ -152,7 +152,7 @@
             android:name="com.daviancorp.android.ui.list.WeaponSelectionListActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop">
+            android:launchMode="singleTask">
             </activity>
         <activity
             android:name="com.daviancorp.android.ui.list.WeaponListActivity"
@@ -177,7 +177,7 @@
             android:name="com.daviancorp.android.ui.list.WishlistListActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
         <activity
             android:name="com.daviancorp.android.ui.detail.WishlistDetailActivity"
             android:label="@string/app_name"
@@ -192,7 +192,7 @@
             android:name="com.daviancorp.android.ui.detail.ArmorSetBuilderActivity"
               android:label="@string/app_name"
               android:screenOrientation="portrait"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/daviancorp/android/ui/detail/WeaponTreeFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/WeaponTreeFragment.java
@@ -99,6 +99,11 @@ public class WeaponTreeFragment extends ListFragment implements
 			
 			TextView weaponView = (TextView) view.findViewById(R.id.name_text);
 			String cellWeaponText = weapon.getName();
+
+			if(weapon.getCreationCost() > 0){
+				cellWeaponText = cellWeaponText + "\u2605";
+			}
+
 			weaponView.setText(cellWeaponText);
 
             View arrowView = (View) view.findViewById(R.id.arrow);

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
@@ -6,6 +6,7 @@ import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.view.GravityCompat;
@@ -59,7 +60,18 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
     private DrawerAdapter mDrawerAdapter;
     public ActionBarDrawerToggle mDrawerToggle;
     public DrawerLayout mDrawerLayout;
+    private Handler mHandler;
+
+    // start drawer in the closed position unless otherwise specified
     private static boolean drawerOpened = false;
+
+    // delay to launch nav drawer item, to allow close animation to play
+    private static final int NAVDRAWER_LAUNCH_DELAY = 250;
+
+    // fade in and fade out durations for the main content when switching between
+    // different Activities of the app through the Nav Drawer
+    private static final int MAIN_CONTENT_FADEOUT_DURATION = 1500;
+    private static final int MAIN_CONTENT_FADEIN_DURATION = 250;
 
     public interface ActionOnCloseListener {
         void actionOnClose();
@@ -71,6 +83,9 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Handler to implement drawer delay and runnable
+        mHandler = new Handler();
     }
 
 
@@ -83,52 +98,16 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
         addDrawerItems();
         mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Set navigation actions
-                Intent intent = new Intent();
+            public void onItemClick(AdapterView<?> parent, View view, final int position, long id) {
 
-                switch (position) {
-                    case 0: // Monsters
-                        intent = new Intent(getApplicationContext(), MonsterListActivity.class);
-                        break;
-                    case 1: // Weapons
-                        intent = new Intent(getApplicationContext(), WeaponSelectionListActivity.class);
-                        break;
-                    case 2: // Armor
-                        intent = new Intent(getApplicationContext(), ArmorListActivity.class);
-                        break;
-                    case 3: // Quests
-                        intent = new Intent(getApplicationContext(), QuestListActivity.class);
-                        break;
-                    case 4: // Items
-                        intent = new Intent(getApplicationContext(), ItemListActivity.class);
-                        break;
-                    case 5: // Combining
-                        intent = new Intent(getApplicationContext(), CombiningListActivity.class);
-                        break;
-                    case 6: // Locations
-                        intent = new Intent(getApplicationContext(), LocationListActivity.class);
-                        break;
-                    case 7: // Decorations
-                        intent = new Intent(getApplicationContext(), DecorationListActivity.class);
-                        break;
-                    case 8: // Skill Trees
-                        intent = new Intent(getApplicationContext(), SkillTreeListActivity.class);
-                        break;
-                    case 9: // Wishlists
-                        intent = new Intent(getApplicationContext(), WishlistListActivity.class);
-                        break;
-                }
-                final Intent finalIntent = intent;
-                // Clear the back stack whenever a nav drawer item is selected
-                //intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_TASK_ON_HOME);
-                actionOnCloseListener = new ActionOnCloseListener() {
+                // Wait for drawer to close. This actually waits too long. Turn it into a runnable.
+                mHandler.postDelayed(new Runnable() {
                     @Override
-                    public void actionOnClose() {
-                        startActivity(finalIntent);
-                        //overridePendingTransition(R.anim.abc_fade_in, R.anim.abc_fade_out);
+                    public void run() {
+                        goToNavDrawerItem(position);
                     }
-                };
+                }, NAVDRAWER_LAUNCH_DELAY);
+
                 mDrawerLayout.closeDrawers();
             }
         });
@@ -162,6 +141,54 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
         }
     }
 
+    // Go to nav drawer selection
+    private void goToNavDrawerItem(int itemId){
+        // Set navigation actions
+        Intent intent = new Intent();
+
+        switch (itemId) {
+            case 0: // Monsters
+                intent = new Intent(GenericActionBarActivity.this, MonsterListActivity.class);
+                break;
+            case 1: // Weapons
+                intent = new Intent(GenericActionBarActivity.this, WeaponSelectionListActivity.class);
+                break;
+            case 2: // Armor
+                intent = new Intent(GenericActionBarActivity.this, ArmorListActivity.class);
+                break;
+            case 3: // Quests
+                intent = new Intent(GenericActionBarActivity.this, QuestListActivity.class);
+                break;
+            case 4: // Items
+                intent = new Intent(GenericActionBarActivity.this, ItemListActivity.class);
+                break;
+            case 5: // Combining
+                intent = new Intent(GenericActionBarActivity.this, CombiningListActivity.class);
+                break;
+            case 6: // Locations
+                intent = new Intent(GenericActionBarActivity.this, LocationListActivity.class);
+                break;
+            case 7: // Decorations
+                intent = new Intent(GenericActionBarActivity.this, DecorationListActivity.class);
+                break;
+            case 8: // Skill Trees
+                intent = new Intent(GenericActionBarActivity.this, SkillTreeListActivity.class);
+                break;
+            case 9: // Wishlists
+                intent = new Intent(GenericActionBarActivity.this, WishlistListActivity.class);
+                break;
+        }
+        final Intent finalIntent = intent;
+
+        // Clear the back stack whenever a nav drawer item is selected
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+
+        startActivity(finalIntent);
+
+        // Clear default animation
+        overridePendingTransition(0, 0);
+    }
+
     // Set up drawer menu options
     private void addDrawerItems() {
         String[] menuArray = getResources().getStringArray(R.array.drawer_items);
@@ -169,7 +196,6 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
         mDrawerAdapter = new DrawerAdapter(getApplicationContext(), R.layout.drawer_list_item, menuArray);
         mDrawerList.setAdapter(mDrawerAdapter);
     }
-
 
     public void enableDrawerIndicator() {
         mDrawerToggle.setDrawerIndicatorEnabled(true);
@@ -179,6 +205,12 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
     @Override
     protected void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
+
+        // Animate fade in
+        View mainContent = findViewById(R.id.fragment_container);
+        if(mainContent != null){
+            mainContent.animate().alpha(1).setDuration(MAIN_CONTENT_FADEIN_DURATION);
+        }
         mDrawerToggle.syncState();
     }
 
@@ -206,8 +238,6 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
         if (mDrawerToggle.onOptionsItemSelected(item)) {
             return true;
         }
-
-
 
         // Detect home and or expansion menu item selections
         switch (item.getItemId()) {

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
@@ -70,7 +70,7 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
 
     // fade in and fade out durations for the main content when switching between
     // different Activities of the app through the Nav Drawer
-    private static final int MAIN_CONTENT_FADEOUT_DURATION = 1500;
+    private static final int MAIN_CONTENT_FADEOUT_DURATION = 150; // Unused until fade out animation is properly implemented
     private static final int MAIN_CONTENT_FADEIN_DURATION = 250;
 
     public interface ActionOnCloseListener {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,7 +9,7 @@
 
         <LinearLayout
         android:layout_width="fill_parent"
-        android:layout_height="match_parent"
+        android:layout_height="fill_parent"
         android:id="@+id/fragment_container"
         android:orientation="vertical">
 


### PR DESCRIPTION
Selecting a nav drawer item now starts the activity in its own task. Pressing "BACK" from any of the main activities exits the app. I don't forsee the lack of a "confirm exit" dialog a problem. If we get feedback we may add it as an optional setting.