### PR TITLE
string change, highlight the selected wishlist when in ActionMode

### DIFF
--- a/app/src/main/java/com/daviancorp/android/ui/list/WishlistListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WishlistListFragment.java
@@ -48,8 +48,9 @@ public class WishlistListFragment extends ListFragment implements
 	private static final int REQUEST_RENAME = 1;
 	private static final int REQUEST_COPY = 2;
 	private static final int REQUEST_DELETE = 3;
-	
-	private ActionMode mActionMode;
+
+    private int lastSelectionIndex = 0;
+    private ActionMode mActionMode;
 	private ListView mListView;
 	
 	@Override
@@ -83,7 +84,8 @@ public class WishlistListFragment extends ListFragment implements
 			            }
 			
 			            mActionMode = getActivity().startActionMode(new mActionModeCallback());
-			            mActionMode.setTag(position);
+                        highlightSelection(position);
+                        mActionMode.setTag(position);
 			            mListView.setItemChecked(position, true);
 			            return true;
 			        }
@@ -154,7 +156,8 @@ public class WishlistListFragment extends ListFragment implements
 					mActionMode = getActivity().startActionMode(new mActionModeCallback());
 		            mActionMode.setTag(0);
 					mListView.setItemChecked(0, true);
-				}
+                    highlightSelection(0);
+                }
 				return true;
 			default:
 				return super.onOptionsItemSelected(item);
@@ -197,8 +200,19 @@ public class WishlistListFragment extends ListFragment implements
 		adapter.notifyDataSetChanged();
 		
 	}
-	
-	private boolean onItemSelected(MenuItem item, int position) {
+
+    private void highlightSelection(int position){
+        clearHighlight(lastSelectionIndex);
+        mListView.getChildAt(position).setBackgroundColor(getResources().getColor(R.color.light_primary_color));
+        lastSelectionIndex = position;
+    }
+
+    private void clearHighlight(int position){
+        mListView.getChildAt(lastSelectionIndex).setBackgroundColor(getResources().getColor(R.color.list_background));
+    }
+
+
+    private boolean onItemSelected(MenuItem item, int position) {
 		WishlistListCursorAdapter adapter = (WishlistListCursorAdapter) getListAdapter();
 		Wishlist wishlist = ((WishlistCursor) adapter.getItem(position)).getWishlist();
 		long id = wishlist.getId();
@@ -251,7 +265,8 @@ public class WishlistListFragment extends ListFragment implements
 	    public void onDestroyActionMode(ActionMode mode) {		        
 	        for (int i = 0; i < mListView.getCount(); i++) {
 	        	mListView.setItemChecked(i, false);
-	        }
+                clearHighlight(i);
+            }
 
 	        mActionMode = null;
 	    }
@@ -267,7 +282,8 @@ public class WishlistListFragment extends ListFragment implements
 			startActivity(i);
 		} 
 		// Contextual action bar options
-		else { 
+		else {
+            highlightSelection(position);
             mActionMode.setTag(position);
 		}
 	}

--- a/app/src/main/res/drawable/list_view_generic.xml
+++ b/app/src/main/res/drawable/list_view_generic.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:drawable="@color/light_primary_color"/>
+    <item android:state_focused="true" android:drawable="@color/light_primary_color"/>
+    <item android:state_pressed="true" android:drawable="@color/light_primary_color"/>
+    <item android:state_selected="true" android:drawable="@color/light_primary_color"/>
+    <item android:state_single="true" android:drawable="@color/light_primary_color"/>
+    <item android:drawable="@color/list_background"/>
+</selector>

--- a/app/src/main/res/layout/fragment_list_view_generic.xml
+++ b/app/src/main/res/layout/fragment_list_view_generic.xml
@@ -8,4 +8,5 @@
     android:paddingStart="?android:attr/listPreferredItemPaddingStart"
     android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
     android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:background="@drawable/list_view_generic"
 />

--- a/app/src/main/res/menu/menu_wishlist_list.xml
+++ b/app/src/main/res/menu/menu_wishlist_list.xml
@@ -11,6 +11,6 @@
         android:id="@+id/wishlist_edit"
         android:icon="@drawable/ic_menu_edit"
         android:showAsAction="ifRoom"
-        android:title="@string/option_wishlist_data_edit"/>
+        android:title="@string/option_wishlist_edit"/>
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     <string name="option_wishlist_copy">Copy wishlist</string>
     <string name="option_wishlist_rename">Rename wishlist</string>
     <string name="option_wishlist_data_add">Create new wishlist</string>
-    <string name="option_wishlist_data_edit">Edit quantity</string>
+    <string name="option_wishlist_data_edit">Edit wishlist</string>
     <string name="option_wishlist_data_delete">Delete from wishlist</string>
     <string name="search_title">Search item</string>
     <string name="monsters">Monsters</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,8 +50,9 @@
     <string name="option_wishlist_delete">Delete wishlist</string>
     <string name="option_wishlist_copy">Copy wishlist</string>
     <string name="option_wishlist_rename">Rename wishlist</string>
+    <string name="option_wishlist_edit">Edit wishlist</string>
     <string name="option_wishlist_data_add">Create new wishlist</string>
-    <string name="option_wishlist_data_edit">Edit wishlist</string>
+    <string name="option_wishlist_data_edit">Edit quantity</string>
     <string name="option_wishlist_data_delete">Delete from wishlist</string>
     <string name="search_title">Search item</string>
     <string name="monsters">Monsters</string>


### PR DESCRIPTION
Fixed [this](https://trello.com/c/2I7K6bSQ/234-wishlist-main-page-menu-button-says-edit-quantity-but-it-actually-renames-a-wishlist) issue.

Still learning android... it seems like the new background drawable should have handled the highlighting for the selected wishlist listview item but it didn't.... so I created some private methods that handled it. The drawable is still useful though since it does give it the nice long press animation.

Let me know what changes I can make to the fix. :smile: 