### PR TITLE
Implement Wyporium Trading UI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -193,6 +193,14 @@
               android:label="@string/app_name"
               android:screenOrientation="portrait"
             android:launchMode="singleTask"/>
+
+        <!-- WYPORIUM TRADE SECTION -->
+        <activity
+            android:name="com.daviancorp.android.ui.list.WyporiumTradeListActivity"
+            android:label="@string/app_name"
+            android:screenOrientation="portrait"
+            android:launchMode="singleTask"/>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/daviancorp/android/data/classes/WyporiumTrade.java
+++ b/app/src/main/java/com/daviancorp/android/data/classes/WyporiumTrade.java
@@ -1,0 +1,99 @@
+package com.daviancorp.android.data.classes;
+
+public class WyporiumTrade {
+
+    private long id;                    // Trade id
+    private long itemInId;              // Item in id
+    private String itemInName;          // Item in name
+    private String itemInIconName;      // Item in icon name
+    private long itemOutId;             // Item out id
+    private String itemOutName;         // Item out name
+    private String itemOutIconName;     // Item out icon name
+    private long unlockQuestId;         // Unlock quest id
+    private String unlockQuestName;     // Unlock quest name
+
+    /* Default Constructor */
+    public WyporiumTrade() {
+        this.id = -1;
+        this.itemInId = -1;
+        this.itemInName = "";
+        this.itemInIconName = "";
+        this.itemOutId = -1;
+        this.itemOutName = "";
+        this.itemOutIconName = "";
+        this.unlockQuestId = -1;
+        this.unlockQuestName = "";
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public long getItemInId() {
+        return itemInId;
+    }
+
+    public void setItemInId(long itemInId) {
+        this.itemInId = itemInId;
+    }
+
+    public String getItemInName() {
+        return itemInName;
+    }
+
+    public void setItemInName(String itemInName) {
+        this.itemInName = itemInName;
+    }
+
+    public String getItemInIconName() {
+        return itemInIconName;
+    }
+
+    public void setItemInIconName(String itemInIconName) {
+        this.itemInIconName = itemInIconName;
+    }
+
+    public long getItemOutId() {
+        return itemOutId;
+    }
+
+    public void setItemOutId(long itemOutId) {
+        this.itemOutId = itemOutId;
+    }
+
+    public String getItemOutName() {
+        return itemOutName;
+    }
+
+    public void setItemOutName(String itemOutName) {
+        this.itemOutName = itemOutName;
+    }
+
+    public String getItemOutIconName() {
+        return itemOutIconName;
+    }
+
+    public void setItemOutIconName(String itemOutIconName) {
+        this.itemOutIconName = itemOutIconName;
+    }
+
+    public long getUnlockQuestId() {
+        return unlockQuestId;
+    }
+
+    public void setUnlockQuestId(long unlockQuestId) {
+        this.unlockQuestId = unlockQuestId;
+    }
+
+    public String getUnlockQuestName() {
+        return unlockQuestName;
+    }
+
+    public void setUnlockQuestName(String unlockQuestName) {
+        this.unlockQuestName = unlockQuestName;
+    }
+}

--- a/app/src/main/java/com/daviancorp/android/data/database/DataManager.java
+++ b/app/src/main/java/com/daviancorp/android/data/database/DataManager.java
@@ -1373,12 +1373,12 @@ public class DataManager {
 	}
 
     /**************************** WYPORIUM TRADE DATA QUERIES *************************************/
-    	/* Get a Cursor that has a list of all Decorations */
+    	/* Get a Cursor that has a list of all wyporium trades */
     public WyporiumTradeCursor queryWyporiumTrades() {
         return mHelper.queryWyporiumTrades();
     }
 
-    /* Get a specific Decoration */
+    /* Get a specific wyporium trade */
     public WyporiumTrade getWyporiumTrade(long id) {
         WyporiumTrade wyporiumTrade = null;
         WyporiumTradeCursor cursor = mHelper.queryWyporiumTrades(id);

--- a/app/src/main/java/com/daviancorp/android/data/database/DataManager.java
+++ b/app/src/main/java/com/daviancorp/android/data/database/DataManager.java
@@ -32,7 +32,9 @@ import com.daviancorp.android.data.classes.Weapon;
 import com.daviancorp.android.data.classes.Wishlist;
 import com.daviancorp.android.data.classes.WishlistComponent;
 import com.daviancorp.android.data.classes.WishlistData;
+import com.daviancorp.android.data.classes.WyporiumTrade;
 import com.daviancorp.android.ui.general.WeaponListEntry;
+
 
 /*
  * Singleton class
@@ -1369,4 +1371,22 @@ public class DataManager {
 		
 		wdc.close();
 	}
+
+    /**************************** WYPORIUM TRADE DATA QUERIES *************************************/
+    	/* Get a Cursor that has a list of all Decorations */
+    public WyporiumTradeCursor queryWyporiumTrades() {
+        return mHelper.queryWyporiumTrades();
+    }
+
+    /* Get a specific Decoration */
+    public WyporiumTrade getWyporiumTrade(long id) {
+        WyporiumTrade wyporiumTrade = null;
+        WyporiumTradeCursor cursor = mHelper.queryWyporiumTrades(id);
+        cursor.moveToFirst();
+
+        if (!cursor.isAfterLast())
+            wyporiumTrade = cursor.getWyporiumTrade();
+        cursor.close();
+        return wyporiumTrade;
+    }
 }

--- a/app/src/main/java/com/daviancorp/android/data/database/MonsterHunterDatabaseHelper.java
+++ b/app/src/main/java/com/daviancorp/android/data/database/MonsterHunterDatabaseHelper.java
@@ -3168,7 +3168,7 @@ class MonsterHunterDatabaseHelper extends SQLiteAssetHelper {
     }
 
     /*
-     * Helper method to query for decorations
+     * Helper method to query for wyporium trades
      */
     private SQLiteQueryBuilder builderWyporiumTrade() {
 //      SELECT wt._id AS trade_id, wt.item_in_id AS in_id, wt.item_out_id AS out_id, wt.unlock_quest_id AS q_id,

--- a/app/src/main/java/com/daviancorp/android/data/database/MonsterHunterDatabaseHelper.java
+++ b/app/src/main/java/com/daviancorp/android/data/database/MonsterHunterDatabaseHelper.java
@@ -3128,5 +3128,80 @@ class MonsterHunterDatabaseHelper extends SQLiteAssetHelper {
 		QB.setProjectionMap(projectionMap);
 		return QB;
 	}
-	
+
+    /****************************** WYPORIUM TRADE QUERIES ****************************************/
+
+	/*
+	 * Get all trades
+	 */
+    public WyporiumTradeCursor queryWyporiumTrades() {
+
+        QueryHelper qh = new QueryHelper();
+        qh.Columns = null;
+        qh.Table = S.TABLE_WYPORIUM_TRADE;
+        qh.Selection = null;
+        qh.SelectionArgs = null;
+        qh.GroupBy = null;
+        qh.Having = null;
+        qh.OrderBy = null;
+        qh.Limit = null;
+
+        return new WyporiumTradeCursor(wrapJoinHelper(builderWyporiumTrade(), qh));
+    }
+
+    /*
+	 * Get a specific wyporium trade
+	 */
+    public WyporiumTradeCursor queryWyporiumTrades(long id) {
+
+        QueryHelper qh = new QueryHelper();
+        qh.Columns = null;
+        qh.Table = S.TABLE_WYPORIUM_TRADE;
+        qh.Selection = "wt.item_in_id" + " = ?";
+        qh.SelectionArgs = new String[]{ String.valueOf(id) };
+        qh.GroupBy = null;
+        qh.Having = null;
+        qh.OrderBy = null;
+        qh.Limit = "1";
+
+        return new WyporiumTradeCursor(wrapJoinHelper(builderWyporiumTrade(), qh));
+    }
+
+    /*
+     * Helper method to query for decorations
+     */
+    private SQLiteQueryBuilder builderWyporiumTrade() {
+//      SELECT wt._id AS trade_id, wt.item_in_id AS in_id, wt.item_out_id AS out_id, wt.unlock_quest_id AS q_id,
+//      i1.name AS in_name, i1.icon_name AS in_icon_name, i2.name AS out_name, i2.icon_name AS out_icon_name,
+//      q.name AS q_name
+//      FROM wyporium AS wt LEFT OUTER JOIN items AS i1 ON wt.item_in_id = i1._id
+//      LEFT OUTER JOIN items AS i2 ON wt.item_out_id = i2._id
+//      LEFT OUTER JOIN quests AS q ON wt.unlock_quest_id = q._id;
+
+        HashMap<String, String> projectionMap = new HashMap<String, String>();
+        projectionMap.put("trade_id", "wt." + S.COLUMN_WYPORIUM_TRADE_ID + " AS " + "trade_id");
+        projectionMap.put("in_id", "wt." + S.COLUMN_WYPORIUM_TRADE_ITEM_IN_ID + " AS " + "in_id");
+        projectionMap.put("out_id", "wt." + S.COLUMN_WYPORIUM_TRADE_ITEM_OUT_ID + " AS " + "out_id");
+        projectionMap.put("q_id", "wt." + S.COLUMN_WYPORIUM_TRADE_UNLOCK_QUEST_ID + " AS " + "q_id");
+        projectionMap.put(S.COLUMN_ITEMS_ID, "i1." + S.COLUMN_ITEMS_ID);
+        projectionMap.put("in_name", "i1." + S.COLUMN_ITEMS_NAME + " AS " + "in_name");
+        projectionMap.put("in_icon_name", "i1." + S.COLUMN_ITEMS_ICON_NAME + " AS " + "in_icon_name");
+        projectionMap.put(S.COLUMN_ITEMS_ID, "i2." + S.COLUMN_ITEMS_ID);
+        projectionMap.put("out_name", "i2." + S.COLUMN_ITEMS_NAME + " AS " + "out_name");
+        projectionMap.put("out_icon_name", "i2." + S.COLUMN_ITEMS_ICON_NAME + " AS " + "out_icon_name");
+        projectionMap.put(S.COLUMN_QUESTS_ID, "q." + S.COLUMN_QUESTS_ID);
+        projectionMap.put("q_name", "q." + S.COLUMN_QUESTS_NAME + " AS " + "q_name");
+
+        //Create new querybuilder
+        SQLiteQueryBuilder QB = new SQLiteQueryBuilder();
+
+        QB.setTables(S.TABLE_WYPORIUM_TRADE + " AS wt" + " LEFT OUTER JOIN " + S.TABLE_ITEMS + " AS i1" + " ON " + "wt." +
+                S.COLUMN_WYPORIUM_TRADE_ITEM_IN_ID + " = " + "i1." + S.COLUMN_ITEMS_ID + " LEFT OUTER JOIN " + S.TABLE_ITEMS +
+                " AS i2 " + " ON " + "wt." + S.COLUMN_WYPORIUM_TRADE_ITEM_OUT_ID + " = " + "i2." + S.COLUMN_ITEMS_ID +
+                " LEFT OUTER JOIN " + S.TABLE_QUESTS + " AS q " + " ON " + "wt." + S.COLUMN_WYPORIUM_TRADE_UNLOCK_QUEST_ID + " = " +
+                "q." + S.COLUMN_QUESTS_ID );
+
+        QB.setProjectionMap(projectionMap);
+        return QB;
+    }
 }

--- a/app/src/main/java/com/daviancorp/android/data/database/S.java
+++ b/app/src/main/java/com/daviancorp/android/data/database/S.java
@@ -347,4 +347,11 @@ public class S {
 	static final String COLUMN_WISHLIST_COMPONENT_COMPONENT_ID = "component_id";
 	static final String COLUMN_WISHLIST_COMPONENT_QUANTITY = "quantity";
 	static final String COLUMN_WISHLIST_COMPONENT_NOTES = "notes";
+
+    // Wyporium Trades
+    static final String TABLE_WYPORIUM_TRADE = "wyporium";
+    static final String COLUMN_WYPORIUM_TRADE_ID = "_id";
+    static final String COLUMN_WYPORIUM_TRADE_ITEM_IN_ID = "item_in_id";
+    static final String COLUMN_WYPORIUM_TRADE_ITEM_OUT_ID = "item_out_id";
+    static final String COLUMN_WYPORIUM_TRADE_UNLOCK_QUEST_ID = "unlock_quest_id";
 }

--- a/app/src/main/java/com/daviancorp/android/data/database/WyporiumTradeCursor.java
+++ b/app/src/main/java/com/daviancorp/android/data/database/WyporiumTradeCursor.java
@@ -1,0 +1,43 @@
+package com.daviancorp.android.data.database;
+
+import android.database.Cursor;
+import android.database.CursorWrapper;
+
+import com.daviancorp.android.data.classes.WyporiumTrade;
+
+public class WyporiumTradeCursor extends CursorWrapper {
+
+    public WyporiumTradeCursor(Cursor c) {
+        super(c);
+    }
+
+    public WyporiumTrade getWyporiumTrade() {
+        if (isBeforeFirst() || isAfterLast())
+            return null;
+
+        WyporiumTrade wyporiumTrade = new WyporiumTrade();
+
+        long wyporiumTradeId = getLong(getColumnIndex("trade_id"));
+        long itemInId = getLong(getColumnIndex("in_id"));
+        String itemInName = getString(getColumnIndex("in_name"));
+        String itemInIconName = getString(getColumnIndex("in_icon_name"));
+        long itemOutId = getLong(getColumnIndex("out_id"));
+        String itemOutName = getString(getColumnIndex("out_name"));
+        String itemOutIconName = getString(getColumnIndex("out_icon_name"));
+        long unlockQuestId = getLong(getColumnIndex("q_id"));
+        String unlockQuestName = getString(getColumnIndex("q_name"));
+
+
+        wyporiumTrade.setId(wyporiumTradeId);
+        wyporiumTrade.setItemInId(itemInId);
+        wyporiumTrade.setItemInName(itemInName);
+        wyporiumTrade.setItemInIconName(itemInIconName);
+        wyporiumTrade.setItemOutId(itemOutId);
+        wyporiumTrade.setItemOutName(itemOutName);
+        wyporiumTrade.setItemOutIconName(itemOutIconName);
+        wyporiumTrade.setUnlockQuestId(unlockQuestId);
+        wyporiumTrade.setUnlockQuestName(unlockQuestName);
+
+        return wyporiumTrade;
+    }
+}

--- a/app/src/main/java/com/daviancorp/android/loader/WyporiumTradeListCursorLoader.java
+++ b/app/src/main/java/com/daviancorp/android/loader/WyporiumTradeListCursorLoader.java
@@ -1,0 +1,19 @@
+package com.daviancorp.android.loader;
+
+import android.content.Context;
+import android.database.Cursor;
+
+import com.daviancorp.android.data.database.DataManager;
+
+public class WyporiumTradeListCursorLoader extends SQLiteCursorLoader {
+
+    public WyporiumTradeListCursorLoader(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected Cursor loadCursor() {
+        // Query the list of all wyporium trades
+        return DataManager.get(getContext()).queryWyporiumTrades();
+    }
+}

--- a/app/src/main/java/com/daviancorp/android/loader/WyporiumTradeLoader.java
+++ b/app/src/main/java/com/daviancorp/android/loader/WyporiumTradeLoader.java
@@ -1,0 +1,21 @@
+package com.daviancorp.android.loader;
+
+import android.content.Context;
+
+import com.daviancorp.android.data.classes.WyporiumTrade;
+import com.daviancorp.android.data.database.DataManager;
+
+public class WyporiumTradeLoader extends DataLoader<WyporiumTrade> {
+    private long mTradeId;
+
+    public WyporiumTradeLoader(Context context, long tradeId) {
+        super(context);
+        mTradeId = tradeId;
+    }
+
+    @Override
+    public WyporiumTrade loadInBackground() {
+        // Query the specific decoration
+        return DataManager.get(getContext()).getWyporiumTrade(mTradeId);
+    }
+}

--- a/app/src/main/java/com/daviancorp/android/loader/WyporiumTradeLoader.java
+++ b/app/src/main/java/com/daviancorp/android/loader/WyporiumTradeLoader.java
@@ -15,7 +15,7 @@ public class WyporiumTradeLoader extends DataLoader<WyporiumTrade> {
 
     @Override
     public WyporiumTrade loadInBackground() {
-        // Query the specific decoration
+        // Query the specific wyporium trade
         return DataManager.get(getContext()).getWyporiumTrade(mTradeId);
     }
 }

--- a/app/src/main/java/com/daviancorp/android/ui/ClickListeners/WyporiumTradeClickListener.java
+++ b/app/src/main/java/com/daviancorp/android/ui/ClickListeners/WyporiumTradeClickListener.java
@@ -1,0 +1,25 @@
+package com.daviancorp.android.ui.ClickListeners;
+
+import android.content.Context;
+import android.content.Intent;
+import android.view.View;
+
+import com.daviancorp.android.ui.detail.ItemDetailActivity;
+
+public class WyporiumTradeClickListener implements View.OnClickListener {
+    private Context c;
+    private Long id;
+
+    public WyporiumTradeClickListener(Context context, Long id) {
+        super();
+        this.id = id;
+        this.c = context;
+    }
+
+    @Override
+    public void onClick(View v) {
+        Intent i = new Intent(c, ItemDetailActivity.class);
+        i.putExtra(ItemDetailActivity.EXTRA_ITEM_ID, id);
+        c.startActivity(i);
+    }
+}

--- a/app/src/main/java/com/daviancorp/android/ui/adapter/ItemDetailPagerAdapter.java
+++ b/app/src/main/java/com/daviancorp/android/ui/adapter/ItemDetailPagerAdapter.java
@@ -10,6 +10,7 @@ import com.daviancorp.android.ui.detail.ItemDetailFragment;
 import com.daviancorp.android.ui.detail.ItemLocationFragment;
 import com.daviancorp.android.ui.detail.ItemMonsterFragment;
 import com.daviancorp.android.ui.detail.ItemQuestFragment;
+import com.daviancorp.android.ui.detail.ItemTradeFragment;
 import com.daviancorp.android.ui.list.CombiningListFragment;
 
 public class ItemDetailPagerAdapter extends FragmentPagerAdapter {
@@ -18,7 +19,7 @@ public class ItemDetailPagerAdapter extends FragmentPagerAdapter {
 
     // Tab titles
     // TODO: Reenable arena quest tab
-    private String[] tabs = { "Detail", "Combining", "Usage", "Monster", "Quest", "Location"};
+    private String[] tabs = { "Detail", "Combining", "Usage", "Monster", "Quest", "Location", "Trade"};
 
 	public ItemDetailPagerAdapter(FragmentManager fm, long id) {
 		super(fm);
@@ -46,6 +47,9 @@ public class ItemDetailPagerAdapter extends FragmentPagerAdapter {
 		case 5:
 			// Location drops; gathering
 			return ItemLocationFragment.newInstance(itemId);
+        case 6:
+            // Wyporium trade info
+            return ItemTradeFragment.newInstance(itemId);
 //		case 5:
 //			// ArenaQuest rewards
 //            //TODO reenable when arena quests are complete.
@@ -63,7 +67,7 @@ public class ItemDetailPagerAdapter extends FragmentPagerAdapter {
 	@Override
 	public int getCount() {
 		// get item count - equal to number of tabs
-		return 6;
+		return 7;
 	}
 
 }

--- a/app/src/main/java/com/daviancorp/android/ui/adapter/WyporiumTradeDetailPagerAdapter.java
+++ b/app/src/main/java/com/daviancorp/android/ui/adapter/WyporiumTradeDetailPagerAdapter.java
@@ -1,0 +1,44 @@
+package com.daviancorp.android.ui.adapter;
+
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+
+import com.daviancorp.android.ui.detail.ItemTradeFragment;
+
+public class WyporiumTradeDetailPagerAdapter extends FragmentPagerAdapter {
+
+    private long tradeId;
+
+    // Tab titles
+    private String[] tabs = { "Details" };
+
+    public WyporiumTradeDetailPagerAdapter(FragmentManager fm, long id) {
+        super(fm);
+        this.tradeId = id;
+    }
+
+    @Override
+    public Fragment getItem(int index) {
+
+        switch (index) {
+            case 0:
+                // Trade details
+                return ItemTradeFragment.newInstance(tradeId);
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public CharSequence getPageTitle(int index) {
+        return tabs[index];
+    }
+
+    @Override
+    public int getCount() {
+        // get item count - equal to number of tabs
+        return 1;
+    }
+
+}

--- a/app/src/main/java/com/daviancorp/android/ui/detail/ItemTradeFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/ItemTradeFragment.java
@@ -1,0 +1,172 @@
+package com.daviancorp.android.ui.detail;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import android.content.Intent;
+import android.content.res.AssetManager;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.app.LoaderManager.LoaderCallbacks;
+import android.support.v4.content.Loader;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.daviancorp.android.data.classes.WyporiumTrade;
+import com.daviancorp.android.loader.WyporiumTradeLoader;
+import com.daviancorp.android.mh4udatabase.R;
+import com.daviancorp.android.ui.ClickListeners.ItemClickListener;
+
+import org.w3c.dom.Text;
+
+public class ItemTradeFragment extends Fragment {
+    private static final String ARG_ITEM_IN_ID = "ITEM_IN_ID";
+
+    private WyporiumTrade mTrade;
+
+    private TextView mWyporiumTradeItemOutTextView;
+    private ImageView mWyporiumTradeOutIconImageView;
+    private TextView mWyporiumTradeQuestNameTextView;
+    private View mWyporiumTradeItemOutView;
+    private TextView mWyporiumTradeUnlockTextView;
+    private TextView mWyporiumTradeRequiredTextView;
+
+    public static ItemTradeFragment newInstance(long itemInId) {
+        Bundle args = new Bundle();
+        args.putLong(ARG_ITEM_IN_ID, itemInId);
+        ItemTradeFragment f = new ItemTradeFragment();
+        f.setArguments(args);
+        return f;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setRetainInstance(true);
+
+        // Check for a Item ID as an argument, and find the item
+        Bundle args = getArguments();
+        if (args != null) {
+            long itemInId = args.getLong(ARG_ITEM_IN_ID, -1);
+            if (itemInId != -1) {
+                LoaderManager lm = getLoaderManager();
+                lm.initLoader(R.id.wyporium_trade_detail_fragment, args,
+                        new WyporiumTradeLoaderCallbacks());
+            }
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_wyporiumtrade_detail,
+                container, false);
+
+        mWyporiumTradeItemOutTextView = (TextView) view.findViewById(R.id.detail_wt_out_label);
+        mWyporiumTradeOutIconImageView = (ImageView) view.findViewById(R.id.detail_wt_out_image);
+        mWyporiumTradeQuestNameTextView = (TextView) view.findViewById(R.id.detail_wt_quest);
+        mWyporiumTradeItemOutView = view.findViewById(R.id.detail_wt_out_item);
+        mWyporiumTradeUnlockTextView = (TextView) view.findViewById(R.id.detail_wt_required);
+        mWyporiumTradeRequiredTextView = (TextView) view.findViewById(R.id.detail_wt_unlock);
+
+        mWyporiumTradeItemOutView.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // The id argument will be the Monster ID; CursorAdapter gives us this
+                // for free
+                Intent i = new Intent(getActivity(), ItemDetailActivity.class);
+                i.putExtra(ItemDetailActivity.EXTRA_ITEM_ID, (long) v.getTag());
+                startActivity(i);
+            }
+        });
+
+        mWyporiumTradeQuestNameTextView.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // The id argument will be the Monster ID; CursorAdapter gives us this
+                // for free
+                Intent i = new Intent(getActivity(), QuestDetailActivity.class);
+                i.putExtra(QuestDetailActivity.EXTRA_QUEST_ID, (long) v.getTag());
+                startActivity(i);
+            }
+        });
+
+        return view;
+    }
+
+    private void updateUI() throws IOException {
+        if(mTrade == null) {
+            mWyporiumTradeItemOutTextView.setVisibility(View.GONE);
+            mWyporiumTradeOutIconImageView.setVisibility(View.GONE);
+            mWyporiumTradeQuestNameTextView.setVisibility(View.GONE);
+            mWyporiumTradeItemOutView.setVisibility(View.GONE);
+            mWyporiumTradeUnlockTextView.setVisibility(View.GONE);
+            mWyporiumTradeRequiredTextView.setVisibility(View.GONE);
+            return;
+        }
+
+        String cellOutText = mTrade.getItemOutName();
+        String cellInText = mTrade.getItemInName();
+        String cellImageOut = "icons_items/" + mTrade.getItemOutIconName();
+        String cellImageIn = "icons_items/" + mTrade.getItemInIconName();
+        String cellQuestText = mTrade.getUnlockQuestName();
+
+        mWyporiumTradeItemOutTextView.setText(cellOutText);
+        mWyporiumTradeItemOutView.setTag(mTrade.getItemOutId());
+        mWyporiumTradeQuestNameTextView.setText(cellQuestText);
+        mWyporiumTradeQuestNameTextView.setTag(mTrade.getUnlockQuestId());
+
+
+        // Read a Bitmap from Assets
+        AssetManager manager = getActivity().getAssets();
+        InputStream open = null;
+
+        try {
+            open = manager.open(cellImageOut);
+            Bitmap bitmap_out = BitmapFactory.decodeStream(open);
+            // Assign the bitmap to an ImageView in this layout
+            mWyporiumTradeOutIconImageView.setImageBitmap(bitmap_out);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (open != null) {
+                open.close();
+            }
+        }
+    }
+
+    private class WyporiumTradeLoaderCallbacks implements
+            LoaderCallbacks<WyporiumTrade> {
+
+        @Override
+        public Loader<WyporiumTrade> onCreateLoader(int id, Bundle args) {
+            return new WyporiumTradeLoader(getActivity(),
+                    args.getLong(ARG_ITEM_IN_ID));
+        }
+
+        @Override
+        public void onLoadFinished(Loader<WyporiumTrade> loader, WyporiumTrade run) {
+            mTrade = run;
+            try {
+                updateUI();
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+
+        @Override
+        public void onLoaderReset(Loader<WyporiumTrade> loader) {
+            // Do nothing
+        }
+    }
+}

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
@@ -41,6 +41,7 @@ import com.daviancorp.android.ui.list.QuestListActivity;
 import com.daviancorp.android.ui.list.SkillTreeListActivity;
 import com.daviancorp.android.ui.list.WeaponSelectionListActivity;
 import com.daviancorp.android.ui.list.WishlistListActivity;
+import com.daviancorp.android.ui.list.WyporiumTradeListActivity;
 import com.daviancorp.android.ui.list.adapter.MenuSection;
 
 import java.io.IOException;
@@ -176,6 +177,9 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
                 break;
             case 9: // Wishlists
                 intent = new Intent(GenericActionBarActivity.this, WishlistListActivity.class);
+                break;
+            case 10: // Wyporium Trade
+                intent = new Intent(GenericActionBarActivity.this, WyporiumTradeListActivity.class);
                 break;
         }
         final Intent finalIntent = intent;

--- a/app/src/main/java/com/daviancorp/android/ui/general/HomeFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/HomeFragment.java
@@ -27,6 +27,7 @@ import com.daviancorp.android.ui.list.QuestListActivity;
 import com.daviancorp.android.ui.list.SkillTreeListActivity;
 import com.daviancorp.android.ui.list.WeaponSelectionListActivity;
 import com.daviancorp.android.ui.list.WishlistListActivity;
+import com.daviancorp.android.ui.list.WyporiumTradeListActivity;
 
 public class HomeFragment extends Fragment {
 
@@ -34,7 +35,8 @@ public class HomeFragment extends Fragment {
 
     // Options to navigate
     private TextView mMonsters, mWeapons, mArmors, mQuests, mItems, mCombining,
-            mDecorations, mSkillTrees, mLocations, mHuntingFleet, mArenaQuests, mWishlists;
+            mDecorations, mSkillTrees, mLocations, mHuntingFleet, mArenaQuests, mWishlists,
+            mWyporiumTrade;
 
     private ProgressDialog progress;	// Progress spinner upon creating/updating database
 
@@ -63,6 +65,7 @@ public class HomeFragment extends Fragment {
         mLocations = (TextView) v.findViewById(R.id.locations);
         //mArenaQuests = (TextView) v.findViewById(R.id.arena_quests); // Disabled
         mWishlists = (TextView) v.findViewById(R.id.wishlists);
+        mWyporiumTrade = (TextView) v.findViewById(R.id.wyporiumtrade);
 
         mMonsters.setOnClickListener(new OnClickListener() {
             @Override
@@ -136,6 +139,14 @@ public class HomeFragment extends Fragment {
             }
         });
 
+        mWyporiumTrade.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(getActivity(), WyporiumTradeListActivity.class);
+                startActivity(intent);
+            }
+        });
+
 //		mArenaQuests.setOnClickListener(new OnClickListener() {
 //			@Override
 //			public void onClick(View v) {
@@ -151,6 +162,7 @@ public class HomeFragment extends Fragment {
                 startActivity(intent);
             }
         });
+
 
         return v;
     }

--- a/app/src/main/java/com/daviancorp/android/ui/list/WyporiumTradeListActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WyporiumTradeListActivity.java
@@ -1,0 +1,32 @@
+package com.daviancorp.android.ui.list;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+
+import com.daviancorp.android.mh4udatabase.R;
+import com.daviancorp.android.ui.general.GenericActivity;
+import com.daviancorp.android.ui.list.adapter.MenuSection;
+
+public class WyporiumTradeListActivity extends GenericActivity {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setTitle(R.string.wyporiumtrade);
+
+        // Enable drawer button instead of back button
+        super.enableDrawerIndicator();
+    }
+
+    @Override
+    protected MenuSection getSelectedSection() {
+        return MenuSection.WYPORIUM_TRADE;
+    }
+
+    @Override
+    protected Fragment createFragment() {
+        super.detail = new WyporiumTradeListFragment();
+        return super.detail;
+    }
+
+}

--- a/app/src/main/java/com/daviancorp/android/ui/list/WyporiumTradeListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WyporiumTradeListFragment.java
@@ -1,0 +1,131 @@
+package com.daviancorp.android.ui.list;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.database.Cursor;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.v4.app.ListFragment;
+import android.support.v4.app.LoaderManager.LoaderCallbacks;
+import android.support.v4.content.Loader;
+import android.support.v4.widget.CursorAdapter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import com.daviancorp.android.data.classes.WyporiumTrade;
+import com.daviancorp.android.data.database.WyporiumTradeCursor;
+import com.daviancorp.android.loader.WyporiumTradeListCursorLoader;
+import com.daviancorp.android.mh4udatabase.R;
+import com.daviancorp.android.ui.ClickListeners.WyporiumTradeClickListener;
+
+import java.io.IOException;
+
+@TargetApi(Build.VERSION_CODES.HONEYCOMB)
+public class WyporiumTradeListFragment extends ListFragment implements
+        LoaderCallbacks<Cursor> {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setHasOptionsMenu(false);
+        // Initialize the loader to load the list of runs
+        getLoaderManager().initLoader(R.id.wyporium_trade_list_fragment, null, this);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_generic_list, container, false);
+    }
+
+    @Override
+    public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+        // You only ever load the runs, so assume this is the case
+        return new WyporiumTradeListCursorLoader(getActivity());
+    }
+
+    @Override
+    public void onLoadFinished(Loader<Cursor> loader, Cursor cursor) {
+        // Create an adapter to point at this cursor
+        WyporiumTradeListCursorAdapter adapter = new WyporiumTradeListCursorAdapter(
+                getActivity(), (WyporiumTradeCursor) cursor);
+        setListAdapter(adapter);
+
+    }
+
+    @Override
+    public void onLoaderReset(Loader<Cursor> loader) {
+        // Stop using the cursor (via the adapter)
+        setListAdapter(null);
+    }
+
+
+    private static class WyporiumTradeListCursorAdapter extends CursorAdapter {
+
+        private WyporiumTradeCursor mWyporiumTradeCursor;
+
+        public WyporiumTradeListCursorAdapter(Context context,
+                                           WyporiumTradeCursor cursor) {
+            super(context, cursor, 0);
+            mWyporiumTradeCursor = cursor;
+        }
+
+        @Override
+        public View newView(Context context, Cursor cursor, ViewGroup parent) {
+            // Use a layout inflater to get a row view
+            LayoutInflater inflater = (LayoutInflater) context
+                    .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            return inflater.inflate(R.layout.fragment_wyporiumtrade_listitem,
+                    parent, false);
+        }
+
+        @Override
+        public void bindView(View view, Context context, Cursor cursor) {
+            // Get the trade for the current row
+            WyporiumTrade wyporiumTrade = mWyporiumTradeCursor.getWyporiumTrade();
+
+            RelativeLayout itemLayout = (RelativeLayout) view.findViewById(R.id.listitem);
+
+            // Set up the text view
+            ImageView itemInImageView = (ImageView) view.findViewById(R.id.wt_item_in_image);
+            TextView itemInNameTextView = (TextView) view.findViewById(R.id.wt_item_in_name);
+            ImageView itemOutImageView = (ImageView) view.findViewById(R.id.wt_item_out_image);
+            TextView itemOutNameTextView = (TextView) view.findViewById(R.id.wt_item_out_name);
+
+            String itemInNameText = wyporiumTrade.getItemInName();
+            String itemOutNameText = wyporiumTrade.getItemOutName();
+
+            Drawable i = null;
+            String cellImageIn = "icons_items/" + wyporiumTrade.getItemInIconName();
+            String cellImageOut = "icons_items/" + wyporiumTrade.getItemOutIconName();
+            try {
+                i = Drawable.createFromStream(
+                        context.getAssets().open(cellImageIn), null);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            itemInImageView.setImageDrawable(i);
+            i = null;
+
+            try {
+                i = Drawable.createFromStream(
+                        context.getAssets().open(cellImageOut), null);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            itemOutImageView.setImageDrawable(i);
+
+            itemInNameTextView.setText(itemInNameText);
+            itemOutNameTextView.setText(itemOutNameText);
+
+            itemLayout.setTag(wyporiumTrade.getId());
+            itemLayout.setOnClickListener(new WyporiumTradeClickListener(context, wyporiumTrade.getItemInId()));
+        }
+    }
+}

--- a/app/src/main/java/com/daviancorp/android/ui/list/adapter/MenuSection.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/adapter/MenuSection.java
@@ -16,7 +16,8 @@ public enum MenuSection {
     LOCATIONS(6),
     DECORATION(7),
     SKILL_TREES(8),
-    WISH_LISTS(9);
+    WISH_LISTS(9),
+    WYPORIUM_TRADE(10);
 
     public int menuListPosition;
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -168,6 +168,26 @@
             <!--/>-->
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight=".1"
+        android:orientation="horizontal" >
+
+        <TextView
+            android:id="@+id/wyporiumtrade"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight=".5"
+            android:background="@drawable/clicked_states_primary"
+            android:layout_margin="2dp"
+            android:gravity="center"
+            android:text="@string/wyporiumtrade"
+            android:textColor="@color/text_primary_color"
+            android:textSize="20sp" />
+
+    </LinearLayout>
+
     <!--<LinearLayout-->
         <!--android:layout_width="match_parent"-->
         <!--android:layout_height="0dp"-->

--- a/app/src/main/res/layout/fragment_wyporiumtrade_detail.xml
+++ b/app/src/main/res/layout/fragment_wyporiumtrade_detail.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/detail_wt_required"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text = "Required Item:"
+        android:layout_marginRight="10dp"
+        android:layout_gravity="center_vertical"
+        android:padding="10dp" />
+
+    <RelativeLayout
+        android:id="@+id/detail_wt_out_item"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="10dp" >
+
+
+        <ImageView
+            android:id="@+id/detail_wt_out_image"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_gravity="center_vertical"/>
+
+        <TextView
+            android:id="@+id/detail_wt_out_label"
+            android:layout_width="wrap_content"
+            android:layout_height="fill_parent"
+            android:layout_alignTop="@+id/detail_wt_out_image"
+            android:layout_alignBottom="@+id/detail_wt_out_image"
+            android:paddingLeft="10dp"
+            android:gravity="center_vertical"
+            android:layout_toRightOf="@+id/detail_wt_out_image"
+            />
+    </RelativeLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/detail_wt_unlock"
+        android:text = "Quest to Unlock:"
+        android:layout_marginRight="10dp"
+        android:layout_centerVertical="true"
+        android:padding="10dp"/>
+
+    <TextView
+        android:id="@+id/detail_wt_quest"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:padding="10dp"
+        android:layout_marginLeft="10dp"/>
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_wyporiumtrade_listitem.xml
+++ b/app/src/main/res/layout/fragment_wyporiumtrade_listitem.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/list_item"
+    android:layout_width="match_parent"
+    android:id="@+id/listitem">
+
+    <ImageView
+        android:id="@+id/wt_item_out_image"
+        android:layout_centerVertical="true"
+        android:layout_marginRight="10dp"
+        android:layout_height="20dp"
+        android:layout_width="20dp"/>
+
+    <TextView
+        style="@style/text_small"
+        android:text="Item Out"
+        android:id="@+id/wt_item_out_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toRightOf="@+id/wt_item_out_image"
+        android:layout_centerVertical="true" />
+
+    <TextView
+        style="@style/text_medium"
+        android:id="@+id/wt_arrow"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="➝"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true" />
+
+    <ImageView
+        android:id="@+id/wt_item_in_image"
+        android:layout_centerVertical="true"
+        android:layout_height="20dp"
+        android:layout_width="20dp"
+        android:layout_marginLeft="10dp"
+        android:layout_alignParentRight="true" />
+
+    <TextView
+        android:id="@+id/wt_item_in_name"
+        style="@style/text_small"
+        android:textStyle="bold"
+        android:text="Item In"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center_vertical|right"
+        android:layout_toLeftOf="@+id/wt_item_in_image"
+        android:layout_centerVertical="true" />
+
+</RelativeLayout>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -35,6 +35,7 @@
 	<item name="weapon_tree_fragment" type="id"/>
 	<item name="wishlist_data_component_fragment" type="id"/>
 	<item name="wishlist_data_detail_fragment" type="id"/>
+    <item name="wyporium_trade_detail_fragment" type="id"/>
 
 
     <!-- LOADER IDS -->
@@ -61,4 +62,5 @@
 	<item name="skill_tree_list_fragment" type="id"/>
 	<item name="weapon_list_fragment" type="id"/>
 	<item name="wishlist_list_fragment" type="id"/>
+    <item name="wyporium_trade_list_fragment" type="id"/>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
         <item>"Decorations,icons_items/Jewel-White.png"</item>
         <item>"Skills,icons_items/Monster-Jewel-White.png"</item>
         <item>"Wishlists,icons_items/Mantle-White.png"</item>
+        <item>"Wyporium Trade,icons_items/Carapace-White.png"</item>
     </string-array>
 
     <string name="option_list">List</string>
@@ -69,6 +70,7 @@
     <string name="weapons">Weapons</string>
     <string name="arena_quests">Arena Quests</string>
     <string name="wishlist">Wishlists</string>
+    <string name="wyporiumtrade">Wyporium Trade</string>
     <string name="icon_name">MH4U DB</string>
 
     <string name="dialog_armor_filter_title">Filter</string>


### PR DESCRIPTION
Added an option in main menu to see a list of all wyporium trades.
Added a fragment under items to see wyporium trade details.

![screenshot_2015-04-25-22-24-06](https://cloud.githubusercontent.com/assets/2577018/7335625/07d6029a-eb9a-11e4-92f2-6af48cb84449.png)
![2015-04-26 02 24 15](https://cloud.githubusercontent.com/assets/2577018/7335628/18dc0be8-eb9a-11e4-9521-eb5c39026281.png)
![screenshot_2015-04-25-22-24-24](https://cloud.githubusercontent.com/assets/2577018/7335630/2c07827e-eb9a-11e4-8ef9-5003986cf1d5.png)

