### PR TITLE
Wyporium Trade UI

### DIFF
--- a/app/src/main/java/com/daviancorp/android/data/database/DataManager.java
+++ b/app/src/main/java/com/daviancorp/android/data/database/DataManager.java
@@ -120,7 +120,10 @@ public class DataManager {
 	}
 	
 /********************************* ARMOR QUERIES ******************************************/	
-	
+
+	/* Get a cursor that has a list based on a search term */
+	public ArmorCursor queryArmorSearch(String search) { return mHelper.queryArmorSearch(search); }
+
 	/* Get a Cursor that has a list of all Armors */
 	public ArmorCursor queryArmor() {
 		return mHelper.queryArmor();

--- a/app/src/main/java/com/daviancorp/android/data/database/MonsterHunterDatabaseHelper.java
+++ b/app/src/main/java/com/daviancorp/android/data/database/MonsterHunterDatabaseHelper.java
@@ -540,7 +540,25 @@ class MonsterHunterDatabaseHelper extends SQLiteAssetHelper {
 	}
 	
 /********************************* ARMOR QUERIES ******************************************/
-	
+
+
+	/*
+	 * Get armor filtered by search
+	 */
+	public ArmorCursor queryArmorSearch(String search){
+		QueryHelper qh = new QueryHelper();
+		qh.Distinct = false;
+		qh.Columns = null;
+		qh.Selection = "i." + S.COLUMN_ITEMS_NAME + " LIKE ?";
+		qh.SelectionArgs = new String[]{'%' + search + '%'};
+		qh.GroupBy = null;
+		qh.Having = null;
+		qh.OrderBy = null;
+		qh.Limit = null;
+
+		return new ArmorCursor(wrapJoinHelper(builderArmor(), qh));
+	}
+
 	/*
 	 * Get all armor
 	 */

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
@@ -319,8 +319,9 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
         // If top level and drawer is open, prompt for exit
             //Ask the user if they want to quit
             new AlertDialog.Builder(this)
-                    .setTitle(R.string.confirm_exit)
-                    .setPositiveButton(R.string.exit, new DialogInterface.OnClickListener() {
+                    .setTitle(R.string.exit_title)
+                    .setMessage(R.string.exit_dialog)
+                    .setPositiveButton(R.string.exit_confirm, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             //Stop the activity
@@ -328,7 +329,7 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
                         }
 
                     })
-                    .setNegativeButton(R.string.cancel_exit, null)
+                    .setNegativeButton(R.string.exit_cancel, null)
                     .show();
         }
         else{

--- a/app/src/main/java/com/daviancorp/android/ui/list/CombiningListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/CombiningListFragment.java
@@ -12,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -125,8 +126,8 @@ public class CombiningListFragment extends ListFragment implements
 			ImageView itemiv2 = (ImageView) v.findViewById(R.id.item_img2);
 			ImageView itemiv3 = (ImageView) v.findViewById(R.id.item_img3);
 
-			RelativeLayout itemlayout1 = (RelativeLayout) v.findViewById(R.id.item1);
-			RelativeLayout itemlayout2 = (RelativeLayout) v.findViewById(R.id.item2);
+			LinearLayout itemlayout1 = (LinearLayout) v.findViewById(R.id.item1);
+			LinearLayout itemlayout2 = (LinearLayout) v.findViewById(R.id.item2);
 			RelativeLayout itemlayout3 = (RelativeLayout) v.findViewById(R.id.item3);
 
 			TextView percenttv = (TextView) v.findViewById(R.id.percentage);

--- a/app/src/main/java/com/daviancorp/android/ui/list/WyporiumTradeListActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WyporiumTradeListActivity.java
@@ -14,8 +14,8 @@ public class WyporiumTradeListActivity extends GenericActivity {
         super.onCreate(savedInstanceState);
         setTitle(R.string.wyporiumtrade);
 
-        // Enable drawer button instead of back button
-        super.enableDrawerIndicator();
+        // Tag as top level activity
+        super.setAsTopLevel();
     }
 
     @Override

--- a/app/src/main/java/com/daviancorp/android/ui/list/WyporiumTradeListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WyporiumTradeListFragment.java
@@ -14,6 +14,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -98,6 +99,10 @@ public class WyporiumTradeListFragment extends ListFragment implements
             ImageView itemOutImageView = (ImageView) view.findViewById(R.id.wt_item_out_image);
             TextView itemOutNameTextView = (TextView) view.findViewById(R.id.wt_item_out_name);
 
+            // Clickable layouts
+            LinearLayout btnItemIn = (LinearLayout) view.findViewById(R.id.btn_in);
+            LinearLayout btnItemOut = (LinearLayout) view.findViewById(R.id.btn_out);
+
             String itemInNameText = wyporiumTrade.getItemInName();
             String itemOutNameText = wyporiumTrade.getItemOutName();
 
@@ -121,17 +126,16 @@ public class WyporiumTradeListFragment extends ListFragment implements
             }
             itemOutImageView.setImageDrawable(i);
 
+            // Set text
             itemInNameTextView.setText(itemInNameText);
             itemOutNameTextView.setText(itemOutNameText);
 
-            itemInImageView.setTag(wyporiumTrade.getId());
-            itemInImageView.setOnClickListener(new WyporiumTradeClickListener(context, wyporiumTrade.getItemInId()));
-            itemInNameTextView.setTag(wyporiumTrade.getId());
-            itemInNameTextView.setOnClickListener(new WyporiumTradeClickListener(context, wyporiumTrade.getItemInId()));
-            itemOutImageView.setTag(wyporiumTrade.getId());
-            itemOutImageView.setOnClickListener(new WyporiumTradeClickListener(context, wyporiumTrade.getItemOutId()));
-            itemOutNameTextView.setTag(wyporiumTrade.getId());
-            itemOutNameTextView.setOnClickListener(new WyporiumTradeClickListener(context, wyporiumTrade.getItemOutId()));
+            // Set up clickthroughs
+            btnItemIn.setTag(wyporiumTrade.getId());
+            btnItemIn.setOnClickListener(new WyporiumTradeClickListener(context, wyporiumTrade.getItemInId()));
+            btnItemOut.setTag(wyporiumTrade.getId());
+            btnItemOut.setOnClickListener(new WyporiumTradeClickListener(context, wyporiumTrade.getItemOutId()));
+
         }
     }
 }

--- a/app/src/main/res/layout/fragment_combining_listitem.xml
+++ b/app/src/main/res/layout/fragment_combining_listitem.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="horizontal"
-    style="@style/list_item"
-    android:gravity="center_vertical"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/listitem"
+    style="@style/list_item"
     android:layout_height="wrap_content"
-    android:paddingRight="0dp"
-    android:paddingLeft="0dp">
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:clickable="false"
+    android:paddingLeft="0dp"
+    android:paddingRight="0dp">
 
     <RelativeLayout
-        style="@style/list_sub_item"
         android:id="@+id/item3"
-        android:paddingLeft="8dp"
-        android:paddingRight="8dp"
-        android:background="@drawable/clicked_states_white"
+        style="@style/list_sub_item"
+        android:layout_marginLeft="8dp"
         android:layout_marginTop="4dp"
-        android:layout_marginLeft="8dp">
+        android:background="@drawable/clicked_states_white"
+        android:paddingLeft="8dp"
+        android:paddingRight="8dp">
 
         <TextView
             android:id="@+id/percentage"
@@ -23,110 +25,104 @@
             android:layout_width="wrap_content"
             android:layout_height="40dp"
             android:layout_alignParentLeft="false"
-            android:layout_alignParentTop="false"
             android:layout_alignParentRight="true"
+            android:layout_alignParentTop="false"
+            android:layout_centerVertical="true"
             android:gravity="center_vertical"
-            android:text="95%"
-            android:layout_centerVertical="true" />
+            android:text="95%" />
 
         <TextView
             android:id="@+id/amt"
             style="@style/text_small"
             android:layout_width="wrap_content"
             android:layout_height="40dp"
-            android:gravity="center"
-            android:layout_toLeftOf="@+id/percentage"
+            android:layout_centerVertical="true"
             android:layout_marginRight="16dp"
-            android:text="2"
-            android:layout_centerVertical="true" />
+            android:layout_toLeftOf="@+id/percentage"
+            android:gravity="center"
+            android:text="2" />
 
         <ImageView
             android:id="@+id/item_img3"
             style="@style/main_image"
-            android:layout_centerVertical="true"
-            android:layout_alignParentLeft="true" />
+            android:layout_alignParentLeft="true"
+            android:layout_centerVertical="true" />
 
         <TextView
             android:id="@+id/item_text3"
             style="@style/text_medium"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
             android:layout_gravity="center"
-            android:text="Potion"
-            android:gravity="center_vertical"
             android:layout_toRightOf="@+id/item_img3"
-            android:layout_centerVertical="true" />
+            android:gravity="center_vertical"
+            android:text="Potion" />
     </RelativeLayout>
 
-    <RelativeLayout
-        android:layout_width="wrap_content"
-        android:layout_height="52dp"
-        android:layout_alignParentStart="false"
-        android:layout_below="@+id/item3"
-        android:layout_alignParentRight="false"
-        android:layout_marginBottom="8dp"
-        android:paddingRight="8dp"
-        android:paddingLeft="8dp">
+    <LinearLayout
+        style="@style/list_item"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/item3"
+        android:clickable="false"
+        android:gravity="right"
+        android:orientation="vertical">
 
-        <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="26dp"
+        <LinearLayout
             android:id="@+id/item1"
-            android:background="@drawable/clicked_states_white"></RelativeLayout>
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="2dp"
+            android:background="@drawable/clicked_states_white"
+            android:gravity="right"
+            android:orientation="horizontal">
 
-        <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="26dp"
+            <TextView
+                android:id="@+id/item_text1"
+                style="@style/text_small"
+                android:layout_width="wrap_content"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:layout_toLeftOf="@+id/item_img2"
+                android:gravity="center_vertical"
+                tools:text="Dragonbone Artifact" />
+
+            <ImageView
+                android:id="@+id/item_img1"
+                style="@style/small_image"
+                android:layout_gravity="center"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="0dp" />
+
+        </LinearLayout>
+
+        <LinearLayout
             android:id="@+id/item2"
-            android:layout_alignParentBottom="true"
-            android:background="@drawable/clicked_states_white"></RelativeLayout>
-
-        <ImageView
-            android:id="@+id/item_img2"
-            style="@style/small_image"
-            android:layout_gravity="center"
-            android:layout_alignParentRight="true"
-            android:layout_marginRight="0dp"
-            android:layout_marginLeft="16dp"
-            android:layout_centerVertical="true"
-            android:layout_alignParentTop="false"
-            android:layout_alignParentBottom="true" />
-
-        <TextView
-            android:id="@+id/item_text2"
             android:layout_width="wrap_content"
-            android:layout_height="24dp"
-            android:layout_gravity="center"
-            style="@style/text_small"
-            android:layout_toLeftOf="@+id/item_img2"
-            android:text="Dragonbone Artifact"
-            android:layout_centerVertical="true"
-            android:layout_alignParentTop="false"
-            android:gravity="center_vertical"
-            android:layout_alignParentBottom="true" />
+            android:layout_height="wrap_content"
+            android:background="@drawable/clicked_states_white"
+            android:gravity="right"
+            android:orientation="horizontal">
 
-        <ImageView
-            android:id="@+id/item_img1"
-            style="@style/small_image"
-            android:layout_gravity="center"
-            android:layout_marginRight="0dp"
-            android:layout_centerVertical="true"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentBottom="false"
-            android:layout_alignParentRight="true"
-            android:layout_marginLeft="16dp" />
+            <TextView
+                android:id="@+id/item_text2"
+                style="@style/text_small"
+                android:layout_width="wrap_content"
+                android:layout_height="24dp"
+                android:layout_gravity="center"
+                android:gravity="center_vertical"
+                tools:text="Dragonbone Artifact" />
 
-        <TextView
-            android:id="@+id/item_text1"
-            android:layout_width="wrap_content"
-            android:layout_height="24dp"
-            android:layout_gravity="center"
-            style="@style/text_small"
-            android:text="Dragonbone Artifact"
-            android:layout_centerVertical="true"
-            android:gravity="center_vertical"
-            android:layout_alignParentTop="true"
-            android:layout_toLeftOf="@+id/item_img1" />
-    </RelativeLayout>
+            <ImageView
+                android:id="@+id/item_img2"
+                style="@style/small_image"
+                android:layout_gravity="center"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="0dp" />
+
+        </LinearLayout>
+
+    </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_wyporiumtrade_listitem.xml
+++ b/app/src/main/res/layout/fragment_wyporiumtrade_listitem.xml
@@ -2,9 +2,10 @@
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/listitem"
     style="@style/list_item"
     android:layout_width="match_parent"
-    android:id="@+id/listitem">
+    android:clickable="false">
 
     <LinearLayout
         android:layout_width="fill_parent"
@@ -26,26 +27,26 @@
             <TextView
                 android:id="@+id/wt_item_out_name"
                 style="@style/text_small"
-                tools:text="Very Very Long Name for an Item Out, Even Longer"
-                android:layout_height="match_parent"
                 android:layout_width="0dp"
-                android:layout_weight="0.50"
+                android:layout_height="match_parent"
                 android:layout_centerVertical="true"
+                android:layout_weight="0.50"
+                android:gravity="center_vertical|left"
                 android:scrollHorizontally="false"
-                android:gravity="center_vertical|left" />
+                tools:text="Very Very Long Name for an Item Out, Even Longer" />
         </LinearLayout>
 
         <TextView
             android:id="@+id/wt_arrow"
             style="@style/text_small"
             android:layout_width="0dp"
-            android:layout_weight="0.1"
             android:layout_height="match_parent"
-            android:text="➝"
-            android:gravity="center"
             android:layout_centerHorizontal="true"
             android:layout_centerVertical="true"
-            android:padding="5dp" />
+            android:layout_weight="0.1"
+            android:gravity="center"
+            android:padding="5dp"
+            android:text="➝" />
 
         <LinearLayout
             android:id="@+id/btn_in"
@@ -62,12 +63,12 @@
             <TextView
                 android:id="@+id/wt_item_in_name"
                 style="@style/text_small"
-                tools:text="Also very long Item In"
                 android:layout_width="0dp"
-                android:layout_weight="0.49"
                 android:layout_height="match_parent"
+                android:layout_weight="0.49"
+                android:gravity="center_vertical|left"
                 android:scrollHorizontally="false"
-                android:gravity="center_vertical|left" />
+                tools:text="Also very long Item In" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_wyporiumtrade_listitem.xml
+++ b/app/src/main/res/layout/fragment_wyporiumtrade_listitem.xml
@@ -1,68 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/list_item"
     android:layout_width="match_parent"
-    android:id="@+id/listitem"
-    android:layout_height="wrap_content">
-
-    <ImageView
-        android:id="@+id/wt_item_out_image"
-        android:layout_centerVertical="true"
-        android:layout_height="25dp"
-        android:layout_width="25dp"/>
+    android:id="@+id/listitem">
 
     <LinearLayout
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_toRightOf="@+id/wt_item_out_image"
-        android:layout_toLeftOf="@+id/wt_item_in_image"
-        android:padding="5dp">
-        <TextView
-            android:id="@+id/wt_item_out_name"
-            style="@style/text_small"
-            android:text="Very Very Long Name for an Item Out, Even Longer"
-            android:layout_height="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:id="@+id/btn_out"
             android:layout_width="0dp"
-            android:layout_weight="0.45"
-            android:layout_centerVertical="true"
-            android:scrollHorizontally="false"
-            android:gravity="center_vertical|left"
-            android:padding="5dp"/>
+            android:layout_height="match_parent"
+            android:layout_weight=".4"
+            android:background="@drawable/clicked_states_white">
+
+
+            <ImageView
+                android:id="@+id/wt_item_out_image"
+                style="@style/main_image"
+                android:gravity="center_vertical" />
+
+            <TextView
+                android:id="@+id/wt_item_out_name"
+                style="@style/text_small"
+                tools:text="Very Very Long Name for an Item Out, Even Longer"
+                android:layout_height="match_parent"
+                android:layout_width="0dp"
+                android:layout_weight="0.50"
+                android:layout_centerVertical="true"
+                android:scrollHorizontally="false"
+                android:gravity="center_vertical|left" />
+        </LinearLayout>
 
         <TextView
             android:id="@+id/wt_arrow"
-            style="@style/text_medium"
+            style="@style/text_small"
             android:layout_width="0dp"
             android:layout_weight="0.1"
             android:layout_height="match_parent"
             android:text="➝"
             android:gravity="center"
             android:layout_centerHorizontal="true"
-            android:layout_centerVertical="true"/>
-
-
-        <TextView
-            android:id="@+id/wt_item_in_name"
-            style="@style/text_small"
-            android:textStyle="bold"
-            android:text="Also very long Item In"
-            android:layout_width="0dp"
-            android:layout_weight="0.45"
-            android:layout_height="match_parent"
-            android:scrollHorizontally="false"
-            android:gravity="center_vertical|right"
+            android:layout_centerVertical="true"
             android:padding="5dp" />
 
+        <LinearLayout
+            android:id="@+id/btn_in"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="0.4"
+            android:background="@drawable/clicked_states_white">
 
+            <ImageView
+                android:id="@+id/wt_item_in_image"
+                style="@style/main_image"
+                android:gravity="center_vertical" />
+
+            <TextView
+                android:id="@+id/wt_item_in_name"
+                style="@style/text_small"
+                tools:text="Also very long Item In"
+                android:layout_width="0dp"
+                android:layout_weight="0.49"
+                android:layout_height="match_parent"
+                android:scrollHorizontally="false"
+                android:gravity="center_vertical|left" />
+
+        </LinearLayout>
 
     </LinearLayout>
-
-    <ImageView
-        android:id="@+id/wt_item_in_image"
-        android:layout_centerVertical="true"
-        android:layout_height="25dp"
-        android:layout_width="25dp"
-        android:layout_alignParentRight="true" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,9 +29,10 @@
     <string name="submit">Submit</string>
 
     <!-- CONFIRM EXIT -->
-    <string name="confirm_exit">CONFIRM EXIT</string>
-    <string name="exit">EXIT</string>
-    <string name="cancel_exit">CANCEL</string>
+    <string name="exit_title">Abandon Quest</string>
+    <string name="exit_dialog">Stop the Quest and return to town?</string>
+    <string name="exit_confirm">Yes</string>
+    <string name="exit_cancel">No</string>
 
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>


### PR DESCRIPTION
Trade UI elements now use inherited styles. Clicking now highlights the item cleanly

Combo UI xml has been simplified to use LinearLayouts. Clicks now highlight the icon and name, rather than the entire row as before.

![](https://dl.pushbulletusercontent.com/QPe61qNbWy9b3aCFfIN2nc7J18OgY8EP/Screenshot_2015-05-05-22-02-29.png)
