### PR TITLE
Changelog implementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,12 @@ dependencies {
     // integration instructions here https://github.com/astuetz/PagerSlidingTabStrip
     compile 'org.apmem.tools:layouts:1.8@aar' // Library for flow layout
     // Resources here https://github.com/ApmeM/android-flowlayout
+    compile 'de.cketti.library.changelog:ckchangelog:1.2.2' // Library to display a changelog on first run
+    // Integration instructions here https://github.com/cketti/ckChangeLog
     compile project(':multilevelexpindlistview')
     compile project(':android-sqlite-asset-helper')
+}
+
+repositories {
+    mavenCentral()
 }

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
@@ -48,6 +48,8 @@ import com.daviancorp.android.ui.list.adapter.MenuSection;
 
 import java.io.IOException;
 
+import de.cketti.library.changelog.ChangeLog;
+
 /*
  * Any subclass needs to:
  *  - override onCreate() to set title
@@ -91,6 +93,12 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
         super.onCreate(savedInstanceState);
 
         isTopLevel = false;
+
+        // Display changelog on first run after update
+        ChangeLog cl = new ChangeLog(this);
+        if (cl.isFirstRun()) {
+            cl.getLogDialog().show();
+        }
 
         // Handler to implement drawer delay and runnable
         mHandler = new Handler();

--- a/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
+++ b/app/src/main/java/com/daviancorp/android/ui/general/GenericActionBarActivity.java
@@ -275,6 +275,11 @@ public abstract class GenericActionBarActivity extends ActionBarActivity {
                 this.finish();
                 return true;
 
+            case R.id.change_log:
+                ChangeLog cl = new ChangeLog(this);
+                cl.getFullLogDialog().show();
+                return true;
+
             case R.id.about:
                 FragmentManager fm = getSupportFragmentManager();
                 AboutDialogFragment dialog = new AboutDialogFragment();

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -9,6 +9,11 @@
         android:title="Send Feedback"/>
 
     <item
+        android:id="@+id/change_log"
+        android:showAsAction="never"
+        android:title="Change Log"/>
+
+    <item
         android:id="@+id/about"
         android:showAsAction="never"
         android:title="@string/about"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,12 @@
     <string name="exit_confirm">Yes</string>
     <string name="exit_cancel">No</string>
 
+    <!-- CHANGELOG DIALOG -->
+    <string name="changelog_full_title">Change Log</string>
+    <string name="changelog_title">What\'s New</string>
+    <string name="changelog_ok_button">OK</string>
+    <string name="changelog_show_full">More…</string>
+
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>
     <string name="logo_description">Logo</string>

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<changelog>
+
+    <release version="1.05" versioncode="105">
+        <change>Added Up button to sub-pages. Has same function as back button without exiting.</change>
+        <change>Add DLC data</change>
+        <change>Fixed Wishlist being deleted on upgrade</change>
+        <change>Default the nav drawer open on launch</change>
+        <change>Fix scrolling Bowgun details</change>
+        <change>Improve Horn Note display</change>
+        <change>Added slots to jewel pages</change>
+        <change>Improve slot display</change>
+        <change>Added a star in weapon list to indicate a craftable weapon</change>
+        <change>Data fixes (Auberon Great Sword, High Metal S armor, Clockwork Insect Glaive,
+        Emperor's Speech Horn, Protection Up Jewel, Wyvern Conciliation,
+        Stygian Superbia, Garuga Lovebirds, Diablos Bashers, Inferno/Paradis, Suzuka Takamaru,
+        Twin Elders, Recriminators, Kecha Wach / Plum Daimyo drops, Cephadrome sleep area)</change>
+        <change>Improve Nav Drawer icons</change>
+        <change>Fix Slagtoth Icon</change>
+        <change>Improve Plum Daimyo, Chameleos, and Gogamazios icons</change>
+        <change>Rename Skill Trees to Skills</change>
+        <change>Reduce nav drawer lag</change>
+        <change>Improve corner menu display</change>
+    </release>
+
+    <release version="1.04" versioncode="104">
+        <change>Fix sizes and layout in Hunting Horn song list</change>
+        <change>Missing Horn Songs</change>
+    </release>
+
+    <release version="1.03" versioncode="103">
+        <change>Fixed not being to see Wishlist edit/delete icons (long-press Wishlist items or materials to bring up the action bar)</change>
+        <change>Complete list of Monster Icons</change>
+        <change>Added Collapsible Weapon Trees (long-press to collapse)</change>
+        <change>List of Hunting Horn Songs on the Hunting Horn details page</change>
+        <change>Complete Weapon List Overhaul</change>
+        <change>Update location maps with better gather points</change>
+        <change>UI tweaks</change>
+        <change>Reduced APK size</change>
+        <change>Various database typos and incorrect data</change>
+        <change>Performance improvements on different lists</change>
+        <change>Better sorting on monster->quest list, item->quest list, and item->location list</change>
+        <change>Decorations sorted by skill name</change>
+        <change>New drawer menu icons</change>
+        <change>Fixed drawer menu icons and text</change>
+        <change>Fixed incorrect Critical Eye +4 skill entry</change>
+    </release>
+
+    <release version="1.02" versioncode="102" >
+        <change>Migrated from ActionBarSherlock to AppCompat</change>
+        <change>Added monster status resistances</change>
+        <change>Updated color scheme across app</change>
+        <change>Updated list view styles across app</change>
+        <change>Added navigation drawer</change>
+        <change>Compressed art assets to reduce application size</change>
+        <change>Fixed some icons which were displaying incorrectly (Lances, Armor Arms)</change>
+        <change>Fixed super broken phials for Bows</change>
+        <change>Added fastscroll support</change>
+        <change>Added support for asynchronous image loading in heavy load listviews</change>
+        <change>Added support for preloading weapons for weapon trees to remove load from list adapter</change>
+        <change>Added combination list to item details page, displays all relevant combos</change>
+        <change>Added alternate low-res maps to improve list loading</change>
+        <change>Fixed incorrect Monster All list after fast tabbing</change>
+    </release>
+
+    <release version="1.01" versioncode="101" >
+        <change>Monster Habitats now appear on the Monster Detail Page</change>
+        <change>Monster Habitats are now listed on the Location Detail Page</change>
+    </release>
+
+    <release version="1.00" versioncode="100">
+        <change>Initial Release</change>
+    </release>
+
+</changelog>

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
 
-    <release version="1.05" versioncode="105">
+    <release version="1.05" versioncode="10">
         <change>Added Up button to sub-pages. Has same function as back button without exiting.</change>
         <change>Add DLC data</change>
         <change>Fixed Wishlist being deleted on upgrade</change>
@@ -23,12 +23,12 @@
         <change>Improve corner menu display</change>
     </release>
 
-    <release version="1.04" versioncode="104">
+    <release version="1.04" versioncode="9">
         <change>Fix sizes and layout in Hunting Horn song list</change>
         <change>Missing Horn Songs</change>
     </release>
 
-    <release version="1.03" versioncode="103">
+    <release version="1.03" versioncode="8">
         <change>Fixed not being to see Wishlist edit/delete icons (long-press Wishlist items or materials to bring up the action bar)</change>
         <change>Complete list of Monster Icons</change>
         <change>Added Collapsible Weapon Trees (long-press to collapse)</change>
@@ -46,7 +46,7 @@
         <change>Fixed incorrect Critical Eye +4 skill entry</change>
     </release>
 
-    <release version="1.02" versioncode="102" >
+    <release version="1.02" versioncode="7" >
         <change>Migrated from ActionBarSherlock to AppCompat</change>
         <change>Added monster status resistances</change>
         <change>Updated color scheme across app</change>
@@ -63,12 +63,12 @@
         <change>Fixed incorrect Monster All list after fast tabbing</change>
     </release>
 
-    <release version="1.01" versioncode="101" >
+    <release version="1.01" versioncode="6" >
         <change>Monster Habitats now appear on the Monster Detail Page</change>
         <change>Monster Habitats are now listed on the Location Detail Page</change>
     </release>
 
-    <release version="1.00" versioncode="100">
+    <release version="1.00" versioncode="5">
         <change>Initial Release</change>
     </release>
 


### PR DESCRIPTION
Changelog now runs when versioncode current > versioncode last. It's hard to test this one but it worked the one time I used it. The one that pops up should only show the recent changes with a dialog button to press to show the full changelog.

There is also a "Change Log" button in the overflow menu used on every page. This shows the full changelog every time.

The change log file is here:
app/src/main/res/xml/changelog_master.xml

Just follow the formatting for newer changes.

![](https://dl.pushbulletusercontent.com/LagVLdWHDAPcLGcrVCAqjfB6KGL1hS4a/Screenshot_2015-05-11-21-23-41.png)
