### PR TITLE
Fixed sharpness not showing up when you first open WeaponDetails

### DIFF
--- a/app/src/main/java/com/daviancorp/android/ui/detail/WeaponBladeDetailFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/detail/WeaponBladeDetailFragment.java
@@ -124,6 +124,8 @@ public class WeaponBladeDetailFragment extends WeaponDetailFragment{
 
 		/* Sharpness */
 		mWeaponSharpnessDrawnView.init(mWeapon.getSharpness1(),mWeapon.getSharpness2());
+        // Redraw sharpness after data is loaded
+        mWeaponSharpnessDrawnView.invalidate();
 
         // String notes to use in notes display and song list
         String notes = "";


### PR DESCRIPTION
Sharpness is actually drawn before data is loaded. Added an invalidate call to redraw it after data is loaded. Not sure why this issue wasn't happening before.