### PR TITLE
Weapon list final only option

### DIFF
--- a/app/src/main/java/com/daviancorp/android/data/database/DataManager.java
+++ b/app/src/main/java/com/daviancorp/android/data/database/DataManager.java
@@ -264,7 +264,7 @@ public class DataManager {
 	public DecorationCursor queryDecorations() {
 		return mHelper.queryDecorations();
 	}
-	
+
 	/* Get a specific Decoration */
 	public Decoration getDecoration(long id) {
 		Decoration decoration = null;
@@ -944,14 +944,14 @@ public class DataManager {
 
 	/* Get a Cursor that has a list of Weapons based on weapon type */
 	public WeaponCursor queryWeaponType(String type) {
-		return mHelper.queryWeaponType(type);
+		return mHelper.queryWeaponType(type, false);
 	}
 
     /* Get an array that has a list of Weapons based on weapon type
     * This method is for preloading info for weapons to prevent lots of
     * work in binding a view to a list */
     public ArrayList<Weapon> queryWeaponTypeArray(String type) {
-        WeaponCursor cursor = mHelper.queryWeaponType(type);
+        WeaponCursor cursor = mHelper.queryWeaponType(type, false);
 
         cursor.moveToFirst();
         ArrayList<Weapon> weapons = new ArrayList<Weapon>();
@@ -968,7 +968,7 @@ public class DataManager {
     /* Get an array of weapon expandable list items
     * */
     public ArrayList<WeaponListEntry> queryWeaponTreeArray(String type) {
-        WeaponCursor cursor = mHelper.queryWeaponType(type);
+        WeaponCursor cursor = mHelper.queryWeaponType(type, false);
 
         cursor.moveToFirst();
         ArrayList<WeaponListEntry> weapons = new ArrayList<WeaponListEntry>();
@@ -997,6 +997,23 @@ public class DataManager {
 
         return weapons;
     }
+
+	/*
+	* Get an array of weapon expandable list items consisting only of the final upgrades
+    */
+	public ArrayList<WeaponListEntry> queryWeaponTreeArrayFinal(String type) {
+		WeaponCursor cursor = mHelper.queryWeaponType(type, true);
+
+		ArrayList<WeaponListEntry> weapons = new ArrayList<>();
+
+		cursor.moveToFirst();
+		while (!cursor.isAfterLast()) {
+			weapons.add(new WeaponListEntry(cursor.getWeapon()));
+			cursor.moveToNext();
+		}
+
+		return weapons;
+	}
 	
 	/* Get a Cursor that has a list of Weapons in the weapon tree for a specified weapon */
 	public WeaponCursor queryWeaponTree(long id) {

--- a/app/src/main/java/com/daviancorp/android/data/database/MonsterHunterDatabaseHelper.java
+++ b/app/src/main/java/com/daviancorp/android/data/database/MonsterHunterDatabaseHelper.java
@@ -2640,12 +2640,15 @@ class MonsterHunterDatabaseHelper extends SQLiteAssetHelper {
     /*
      * Get a specific weapon based on weapon type
      */
-    public WeaponCursor queryWeaponType(String type) {
+    public WeaponCursor queryWeaponType(String type, boolean finalOnly) {
 
         QueryHelper qh = new QueryHelper();
         qh.Columns = null;
         qh.Table = S.TABLE_WEAPONS;
         qh.Selection = "w." + S.COLUMN_WEAPONS_WTYPE + " = ? ";
+        if (finalOnly) {
+            qh.Selection += "AND w." + S.COLUMN_WEAPONS_FINAL + " = 1 ";
+        }
         qh.SelectionArgs = new String[]{type};
         qh.GroupBy = null;
         qh.Having = null;

--- a/app/src/main/java/com/daviancorp/android/ui/adapter/WeaponExpandableListGeneralAdapter.java
+++ b/app/src/main/java/com/daviancorp/android/ui/adapter/WeaponExpandableListGeneralAdapter.java
@@ -41,8 +41,6 @@ public abstract class WeaponExpandableListGeneralAdapter extends MultiLevelExpIn
      */
     private final int mPaddingDP = 4;
 
-    private boolean isPaddingEnabled = true;
-
     // Image cache
     protected LruCache<String, Bitmap> mImageCache;
 
@@ -66,14 +64,6 @@ public abstract class WeaponExpandableListGeneralAdapter extends MultiLevelExpIn
                 return draw.getByteCount() / 1024;
             }
         };
-    }
-
-    /**
-     * Enables or disables weapon left-side padding.
-     * @param enabled
-     */
-    public void setPaddingEnabled(boolean enabled) {
-        this.isPaddingEnabled = enabled;
     }
 
     public Bitmap getBitmapFromMemCache(String key) {
@@ -207,13 +197,9 @@ public abstract class WeaponExpandableListGeneralAdapter extends MultiLevelExpIn
         //holder.colorBand.setVisibility(View.VISIBLE);
         holder.setColorBandColor(weapon.getRarity()-1);
 
-        if (isPaddingEnabled) {
-            int leftPadding = Utils.getPaddingPixels(mContext, mPaddingDP)
-                    * (weaponEntry.getIndentation());
-            holder.setPaddingLeft(leftPadding);
-        } else {
-            holder.setPaddingLeft(0);
-        }
+        int leftPadding = Utils.getPaddingPixels(mContext, mPaddingDP)
+                * (weaponEntry.getIndentation());
+        holder.setPaddingLeft(leftPadding);
 
         //
         // Handle groups

--- a/app/src/main/java/com/daviancorp/android/ui/adapter/WeaponExpandableListGeneralAdapter.java
+++ b/app/src/main/java/com/daviancorp/android/ui/adapter/WeaponExpandableListGeneralAdapter.java
@@ -41,6 +41,8 @@ public abstract class WeaponExpandableListGeneralAdapter extends MultiLevelExpIn
      */
     private final int mPaddingDP = 4;
 
+    private boolean isPaddingEnabled = true;
+
     // Image cache
     protected LruCache<String, Bitmap> mImageCache;
 
@@ -66,6 +68,13 @@ public abstract class WeaponExpandableListGeneralAdapter extends MultiLevelExpIn
         };
     }
 
+    /**
+     * Enables or disables weapon left-side padding.
+     * @param enabled
+     */
+    public void setPaddingEnabled(boolean enabled) {
+        this.isPaddingEnabled = enabled;
+    }
 
     public Bitmap getBitmapFromMemCache(String key) {
         return mImageCache.get(key);
@@ -198,9 +207,13 @@ public abstract class WeaponExpandableListGeneralAdapter extends MultiLevelExpIn
         //holder.colorBand.setVisibility(View.VISIBLE);
         holder.setColorBandColor(weapon.getRarity()-1);
 
-        int leftPadding = Utils.getPaddingPixels(mContext, mPaddingDP)
-                * (weaponEntry.getIndentation());
-        holder.setPaddingLeft(leftPadding);
+        if (isPaddingEnabled) {
+            int leftPadding = Utils.getPaddingPixels(mContext, mPaddingDP)
+                    * (weaponEntry.getIndentation());
+            holder.setPaddingLeft(leftPadding);
+        } else {
+            holder.setPaddingLeft(0);
+        }
 
         //
         // Handle groups

--- a/app/src/main/java/com/daviancorp/android/ui/list/WeaponBladeExpandableFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WeaponBladeExpandableFragment.java
@@ -1,39 +1,15 @@
 package com.daviancorp.android.ui.list;
 
-import android.content.Context;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.LoaderManager;
-import android.support.v4.content.AsyncTaskLoader;
-import android.support.v4.content.Loader;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 
-import com.daviancorp.android.data.classes.Weapon;
-import com.daviancorp.android.data.database.DataManager;
-import com.daviancorp.android.mh4udatabase.R;
 import com.daviancorp.android.ui.adapter.WeaponExpandableListBladeAdapter;
-import com.daviancorp.android.ui.general.WeaponListEntry;
-
-import java.util.ArrayList;
-import java.util.List;
+import com.daviancorp.android.ui.adapter.WeaponExpandableListGeneralAdapter;
 
 /**
  * Created by Mark on 3/3/2015.
  */
-public class WeaponBladeExpandableFragment extends Fragment implements
-        LoaderManager.LoaderCallbacks<ArrayList<WeaponListEntry>> {
-
-    protected static final String ARG_TYPE = "WEAPON_TYPE";
-
-    private WeaponExpandableListBladeAdapter mAdapter;
-    private RecyclerView mRecyclerView;
-    private LinearLayoutManager mLayoutManager;
-    private static final String GROUPS_KEY = "groups_key";
-    private Bundle savedState;
+public class WeaponBladeExpandableFragment extends WeaponListFragment {
 
     public static WeaponBladeExpandableFragment newInstance(String type) {
         Bundle args = new Bundle();
@@ -44,27 +20,8 @@ public class WeaponBladeExpandableFragment extends Fragment implements
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        setHasOptionsMenu(true);
-
-        savedState = savedInstanceState;
-
-        // Initialize the loader to load the list of runs
-        getLoaderManager().initLoader(R.id.weapon_list_fragment, getArguments(), this).forceLoad();
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View rootView = inflater.inflate(R.layout.fragment_weapon_tree_expandable, container, false);
-        mRecyclerView = (RecyclerView) rootView.findViewById(R.id.content_recyclerview);
-        mRecyclerView.setHasFixedSize(true);
-
-        mLayoutManager = new LinearLayoutManager(getActivity());
-        mRecyclerView.setLayoutManager(mLayoutManager);
-
-        mAdapter = new WeaponExpandableListBladeAdapter(getActivity(), new View.OnLongClickListener() {
+    protected WeaponExpandableListGeneralAdapter createWeaponAdapter() {
+        return new WeaponExpandableListBladeAdapter(getActivity(), new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
                 int position = mRecyclerView.getChildPosition(v);
@@ -72,88 +29,6 @@ public class WeaponBladeExpandableFragment extends Fragment implements
 
                 return true;
             }
-        });
-        mRecyclerView.setAdapter(mAdapter);
-
-        // Restores old groups if we are returning to the fragment
-        if (savedInstanceState != null) {
-            List<Integer> groups = savedInstanceState.getIntegerArrayList(GROUPS_KEY);
-            mAdapter.restoreGroups(groups);
-        }
-
-        return rootView;
-    }
-
-    @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-
-        // Restores old groups if we are returning to the fragment
-        if (savedInstanceState != null) {
-            List<Integer> groups = savedInstanceState.getIntegerArrayList(GROUPS_KEY);
-            mAdapter.restoreGroups(groups);
-        }
-    }
-
-    //
-    // Saves current state of groups
-    //
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        outState.putIntegerArrayList(GROUPS_KEY, mAdapter.saveGroups());
-        super.onSaveInstanceState(outState);
-    }
-
-    @Override
-    public void onLoadFinished(Loader<ArrayList<WeaponListEntry>> loader,
-                               ArrayList<WeaponListEntry> weapons) {
-        mRecyclerView.setAdapter(mAdapter);
-        mAdapter.addAll(weapons);
-
-
-    }
-
-    @Override
-    public void onLoaderReset(Loader<ArrayList<WeaponListEntry>> loader) {
-        // Stop using the cursor (via the adapter)
-        mRecyclerView.setAdapter(null);
-        mAdapter.clear();
-    }
-
-    @Override
-    public Loader<ArrayList<WeaponListEntry>> onCreateLoader(int id, Bundle args) {
-        // You only ever load the runs, so assume this is the case
-        String mType = null;
-        if (args != null) {
-            mType = args.getString(ARG_TYPE);
-        }
-        return new WeaponArrayLoader(getActivity().getApplicationContext(), mType);
-    }
-
-    static class WeaponArrayLoader extends AsyncTaskLoader<ArrayList<WeaponListEntry>> {
-        String mType;
-        public WeaponArrayLoader(Context context, String type) {
-            super(context);
-            mType = type;
-        }
-
-        public ArrayList<WeaponListEntry> loadInBackground() {
-            return DataManager.get(getContext()).queryWeaponTreeArray(mType);
-        }
-    }
-
-    @Override
-    public void onPause() {
-        savedState = new Bundle();
-        savedState.putIntegerArrayList(GROUPS_KEY, mAdapter.saveGroups());
-        super.onPause();
-    }
-
-    @Override public void onResume() {
-        if (savedState != null) {
-            List<Integer> groups = savedState.getIntegerArrayList(GROUPS_KEY);
-            mAdapter.restoreGroups(groups);
-        }
-        super.onResume();
+         });
     }
 }

--- a/app/src/main/java/com/daviancorp/android/ui/list/WeaponBowExpandableFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WeaponBowExpandableFragment.java
@@ -1,38 +1,15 @@
 package com.daviancorp.android.ui.list;
 
-import android.content.Context;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.LoaderManager;
-import android.support.v4.content.AsyncTaskLoader;
-import android.support.v4.content.Loader;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 
-import com.daviancorp.android.data.database.DataManager;
-import com.daviancorp.android.mh4udatabase.R;
 import com.daviancorp.android.ui.adapter.WeaponExpandableListBowAdapter;
-import com.daviancorp.android.ui.general.WeaponListEntry;
-
-import java.util.ArrayList;
-import java.util.List;
+import com.daviancorp.android.ui.adapter.WeaponExpandableListGeneralAdapter;
 
 /**
  * Created by Mark on 3/5/2015.
  */
-public class WeaponBowExpandableFragment extends Fragment implements
-        LoaderManager.LoaderCallbacks<ArrayList<WeaponListEntry>> {
-
-    protected static final String ARG_TYPE = "WEAPON_TYPE";
-
-    private WeaponExpandableListBowAdapter mAdapter;
-    private RecyclerView mRecyclerView;
-    private LinearLayoutManager mLayoutManager;
-    private static final String GROUPS_KEY = "groups_key";
-    private Bundle savedState;
+public class WeaponBowExpandableFragment extends WeaponListFragment {
 
     public static WeaponBowExpandableFragment newInstance(String type) {
         Bundle args = new Bundle();
@@ -43,27 +20,8 @@ public class WeaponBowExpandableFragment extends Fragment implements
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        setHasOptionsMenu(true);
-
-        savedState = savedInstanceState;
-
-        // Initialize the loader to load the list of runs
-        getLoaderManager().initLoader(R.id.weapon_list_fragment, getArguments(), this).forceLoad();
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View rootView = inflater.inflate(R.layout.fragment_weapon_tree_expandable, container, false);
-        mRecyclerView = (RecyclerView) rootView.findViewById(R.id.content_recyclerview);
-        mRecyclerView.setHasFixedSize(true);
-
-        mLayoutManager = new LinearLayoutManager(getActivity());
-        mRecyclerView.setLayoutManager(mLayoutManager);
-
-        mAdapter = new WeaponExpandableListBowAdapter(getActivity(), new View.OnLongClickListener() {
+    protected WeaponExpandableListGeneralAdapter createWeaponAdapter() {
+        return new WeaponExpandableListBowAdapter(getActivity(), new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
                 int position = mRecyclerView.getChildPosition(v);
@@ -72,89 +30,5 @@ public class WeaponBowExpandableFragment extends Fragment implements
                 return true;
             }
         });
-        mRecyclerView.setAdapter(mAdapter);
-
-        // Restores old groups if we are returning to the fragment
-        if (savedInstanceState != null) {
-            List<Integer> groups = savedInstanceState.getIntegerArrayList(GROUPS_KEY);
-            mAdapter.restoreGroups(groups);
-        }
-
-        return rootView;
-    }
-
-    @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-
-        // Restores old groups if we are returning to the fragment
-        if (savedInstanceState != null) {
-            List<Integer> groups = savedInstanceState.getIntegerArrayList(GROUPS_KEY);
-            mAdapter.restoreGroups(groups);
-        }
-    }
-
-    //
-// Saves current state of groups
-//
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        outState.putIntegerArrayList(GROUPS_KEY, mAdapter.saveGroups());
-        super.onSaveInstanceState(outState);
-    }
-
-    @Override
-    public void onLoadFinished(Loader<ArrayList<WeaponListEntry>> loader,
-                               ArrayList<WeaponListEntry> weapons) {
-        mRecyclerView.setAdapter(mAdapter);
-        mAdapter.addAll(weapons);
-
-
-    }
-
-    @Override
-    public void onLoaderReset(Loader<ArrayList<WeaponListEntry>> loader) {
-        // Stop using the cursor (via the adapter)
-        mRecyclerView.setAdapter(null);
-        mAdapter.clear();
-    }
-
-    @Override
-    public Loader<ArrayList<WeaponListEntry>> onCreateLoader(int id, Bundle args) {
-        // You only ever load the runs, so assume this is the case
-        String mType = null;
-        if (args != null) {
-            mType = args.getString(ARG_TYPE);
-        }
-        return new WeaponArrayLoader(getActivity().getApplicationContext(), mType);
-    }
-
-    static class WeaponArrayLoader extends AsyncTaskLoader<ArrayList<WeaponListEntry>> {
-        String mType;
-
-        public WeaponArrayLoader(Context context, String type) {
-            super(context);
-            mType = type;
-        }
-
-        public ArrayList<WeaponListEntry> loadInBackground() {
-            return DataManager.get(getContext()).queryWeaponTreeArray(mType);
-        }
-    }
-
-    @Override
-    public void onPause() {
-        savedState = new Bundle();
-        savedState.putIntegerArrayList(GROUPS_KEY, mAdapter.saveGroups());
-        super.onPause();
-    }
-
-    @Override
-    public void onResume() {
-        if (savedState != null) {
-            List<Integer> groups = savedState.getIntegerArrayList(GROUPS_KEY);
-            mAdapter.restoreGroups(groups);
-        }
-        super.onResume();
     }
 }

--- a/app/src/main/java/com/daviancorp/android/ui/list/WeaponBowgunExpandableFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WeaponBowgunExpandableFragment.java
@@ -1,39 +1,15 @@
 package com.daviancorp.android.ui.list;
 
-import android.content.Context;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.LoaderManager;
-import android.support.v4.content.AsyncTaskLoader;
-import android.support.v4.content.Loader;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 
-import com.daviancorp.android.data.database.DataManager;
-import com.daviancorp.android.mh4udatabase.R;
-import com.daviancorp.android.ui.adapter.WeaponExpandableListBowAdapter;
 import com.daviancorp.android.ui.adapter.WeaponExpandableListBowgunAdapter;
-import com.daviancorp.android.ui.general.WeaponListEntry;
-
-import java.util.ArrayList;
-import java.util.List;
+import com.daviancorp.android.ui.adapter.WeaponExpandableListGeneralAdapter;
 
 /**
  * Created by Mark on 3/5/2015.
  */
-public class WeaponBowgunExpandableFragment extends Fragment implements
-        LoaderManager.LoaderCallbacks<ArrayList<WeaponListEntry>> {
-
-    protected static final String ARG_TYPE = "WEAPON_TYPE";
-
-    private WeaponExpandableListBowgunAdapter mAdapter;
-    private RecyclerView mRecyclerView;
-    private LinearLayoutManager mLayoutManager;
-    private static final String GROUPS_KEY = "groups_key";
-    private Bundle savedState;
+public class WeaponBowgunExpandableFragment extends WeaponListFragment {
 
     public static WeaponBowgunExpandableFragment newInstance(String type) {
         Bundle args = new Bundle();
@@ -44,27 +20,8 @@ public class WeaponBowgunExpandableFragment extends Fragment implements
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        setHasOptionsMenu(true);
-
-        savedState = savedInstanceState;
-
-        // Initialize the loader to load the list of runs
-        getLoaderManager().initLoader(R.id.weapon_list_fragment, getArguments(), this).forceLoad();
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View rootView = inflater.inflate(R.layout.fragment_weapon_tree_expandable, container, false);
-        mRecyclerView = (RecyclerView) rootView.findViewById(R.id.content_recyclerview);
-        mRecyclerView.setHasFixedSize(true);
-
-        mLayoutManager = new LinearLayoutManager(getActivity());
-        mRecyclerView.setLayoutManager(mLayoutManager);
-
-        mAdapter = new WeaponExpandableListBowgunAdapter(getActivity(), new View.OnLongClickListener() {
+    protected WeaponExpandableListGeneralAdapter createWeaponAdapter() {
+        return new WeaponExpandableListBowgunAdapter(getActivity(), new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
                 int position = mRecyclerView.getChildPosition(v);
@@ -73,89 +30,5 @@ public class WeaponBowgunExpandableFragment extends Fragment implements
                 return true;
             }
         });
-        mRecyclerView.setAdapter(mAdapter);
-
-        // Restores old groups if we are returning to the fragment
-        if (savedInstanceState != null) {
-            List<Integer> groups = savedInstanceState.getIntegerArrayList(GROUPS_KEY);
-            mAdapter.restoreGroups(groups);
-        }
-
-        return rootView;
-    }
-
-    @Override
-    public void onActivityCreated(Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-
-        // Restores old groups if we are returning to the fragment
-        if (savedInstanceState != null) {
-            List<Integer> groups = savedInstanceState.getIntegerArrayList(GROUPS_KEY);
-            mAdapter.restoreGroups(groups);
-        }
-    }
-
-    //
-// Saves current state of groups
-//
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        outState.putIntegerArrayList(GROUPS_KEY, mAdapter.saveGroups());
-        super.onSaveInstanceState(outState);
-    }
-
-    @Override
-    public void onLoadFinished(Loader<ArrayList<WeaponListEntry>> loader,
-                               ArrayList<WeaponListEntry> weapons) {
-        mRecyclerView.setAdapter(mAdapter);
-        mAdapter.addAll(weapons);
-
-
-    }
-
-    @Override
-    public void onLoaderReset(Loader<ArrayList<WeaponListEntry>> loader) {
-        // Stop using the cursor (via the adapter)
-        mRecyclerView.setAdapter(null);
-        mAdapter.clear();
-    }
-
-    @Override
-    public Loader<ArrayList<WeaponListEntry>> onCreateLoader(int id, Bundle args) {
-        // You only ever load the runs, so assume this is the case
-        String mType = null;
-        if (args != null) {
-            mType = args.getString(ARG_TYPE);
-        }
-        return new WeaponArrayLoader(getActivity().getApplicationContext(), mType);
-    }
-
-    static class WeaponArrayLoader extends AsyncTaskLoader<ArrayList<WeaponListEntry>> {
-        String mType;
-
-        public WeaponArrayLoader(Context context, String type) {
-            super(context);
-            mType = type;
-        }
-
-        public ArrayList<WeaponListEntry> loadInBackground() {
-            return DataManager.get(getContext()).queryWeaponTreeArray(mType);
-        }
-    }
-
-    @Override
-    public void onPause() {
-        savedState = new Bundle();
-        savedState.putIntegerArrayList(GROUPS_KEY, mAdapter.saveGroups());
-        super.onPause();
-    }
-
-    @Override
-    public void onResume() {
-        if (savedState != null) {
-            List<Integer> groups = savedState.getIntegerArrayList(GROUPS_KEY);
-            mAdapter.restoreGroups(groups);
-        }
-        super.onResume();
     }
 }

--- a/app/src/main/java/com/daviancorp/android/ui/list/WeaponListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WeaponListFragment.java
@@ -1,84 +1,149 @@
 package com.daviancorp.android.ui.list;
 
-import android.support.v4.content.AsyncTaskLoader;
 import android.content.Context;
-import android.content.Intent;
-import android.database.Cursor;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.ListFragment;
-import android.support.v4.app.LoaderManager.LoaderCallbacks;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.AsyncTaskLoader;
 import android.support.v4.content.Loader;
-import android.support.v4.widget.CursorAdapter;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.ListView;
+import android.view.ViewGroup;
 
-import com.daviancorp.android.data.classes.Weapon;
 import com.daviancorp.android.data.database.DataManager;
-import com.daviancorp.android.loader.WeaponListCursorLoader;
 import com.daviancorp.android.mh4udatabase.R;
-import com.daviancorp.android.ui.detail.WeaponDetailActivity;
+import com.daviancorp.android.ui.adapter.WeaponExpandableListGeneralAdapter;
+import com.daviancorp.android.ui.general.WeaponListEntry;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.List;
 
-public abstract class WeaponListFragment extends ListFragment implements
-		LoaderCallbacks<ArrayList<Weapon>> {
-	protected static final String ARG_TYPE = "WEAPON_TYPE";
+/**
+ * The superclass for weapons list fragments of every weapon type.
+ */
+public abstract class WeaponListFragment extends Fragment implements
+        LoaderManager.LoaderCallbacks<ArrayList<WeaponListEntry>> {
 
-//	private static final String DIALOG_WISHLIST_DATA_ADD_MULTI = "wishlist_data_add_multi";
-//	private static final int REQUEST_ADD_MULTI = 0;
+    protected static final String ARG_TYPE = "WEAPON_TYPE";
+    private static final String GROUPS_KEY = "groups_key";
 
-	@Override
-	public void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-	}
+    private LinearLayoutManager mLayoutManager;
+    private Bundle savedState;
 
-	
-	@Override
-	public Loader<ArrayList<Weapon>> onCreateLoader(int id, Bundle args) {
-		// You only ever load the runs, so assume this is the case
-		String mType = null;
-		if (args != null) {
-			mType = args.getString(ARG_TYPE);
-		}
-		return new WeaponArrayLoader(getActivity().getApplicationContext(), mType);
-	}
+    // todo: refactor so that these variables don't have to be set to protected
+    protected WeaponExpandableListGeneralAdapter mAdapter;
+    protected RecyclerView mRecyclerView;
 
-	@Override
-	public void onLoaderReset(Loader<ArrayList<Weapon>> loader) {
-		// Stop using the cursor (via the adapter)
-		setListAdapter(null);
-	}
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
-	@Override
-	public abstract void onLoadFinished(Loader<ArrayList<Weapon>> loader, ArrayList<Weapon> weapons);
-	
-	@Override
-	public void onListItemClick(ListView l, View v, int position, long id) {
-		// The id argument will be the Weapon ID; CursorAdapter gives us this
-		// for free
-		Intent i = new Intent(getActivity(), WeaponDetailActivity.class);
-		i.putExtra(WeaponDetailActivity.EXTRA_WEAPON_ID, id);
-		startActivity(i);
-	}
+        setHasOptionsMenu(true);
 
-    static class WeaponArrayLoader extends AsyncTaskLoader<ArrayList<Weapon>> {
+        savedState = savedInstanceState;
+
+        // Initialize the loader to load the list of runs
+        getLoaderManager().initLoader(R.id.weapon_list_fragment, getArguments(), this).forceLoad();
+    }
+
+    /**
+     * Used by onCreateView to build an adapter that creates the actual views for all weapons.
+     * @return
+     */
+    protected abstract WeaponExpandableListGeneralAdapter createWeaponAdapter();
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_weapon_tree_expandable, container, false);
+        mRecyclerView = (RecyclerView) rootView.findViewById(R.id.content_recyclerview);
+        mRecyclerView.setHasFixedSize(true);
+
+        mLayoutManager = new LinearLayoutManager(getActivity());
+        mRecyclerView.setLayoutManager(mLayoutManager);
+
+        mAdapter = createWeaponAdapter();
+        mRecyclerView.setAdapter(mAdapter);
+
+        // Restores old groups if we are returning to the fragment
+        if (savedInstanceState != null) {
+            List<Integer> groups = savedInstanceState.getIntegerArrayList(GROUPS_KEY);
+            mAdapter.restoreGroups(groups);
+        }
+
+        return rootView;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        // Restores old groups if we are returning to the fragment
+        if (savedInstanceState != null) {
+            List<Integer> groups = savedInstanceState.getIntegerArrayList(GROUPS_KEY);
+            mAdapter.restoreGroups(groups);
+        }
+    }
+
+    //
+    // Saves current state of groups
+    //
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putIntegerArrayList(GROUPS_KEY, mAdapter.saveGroups());
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void onLoadFinished(Loader<ArrayList<WeaponListEntry>> loader,
+                               ArrayList<WeaponListEntry> weapons) {
+        mRecyclerView.setAdapter(mAdapter);
+        mAdapter.addAll(weapons);
+    }
+
+    @Override
+    public void onLoaderReset(Loader<ArrayList<WeaponListEntry>> loader) {
+        // Stop using the cursor (via the adapter)
+        mRecyclerView.setAdapter(null);
+        mAdapter.clear();
+    }
+
+    @Override
+    public Loader<ArrayList<WeaponListEntry>> onCreateLoader(int id, Bundle args) {
+        // You only ever load the runs, so assume this is the case
+        String mType = null;
+        if (args != null) {
+            mType = args.getString(ARG_TYPE);
+        }
+        return new WeaponArrayLoader(getActivity().getApplicationContext(), mType);
+    }
+
+    static class WeaponArrayLoader extends AsyncTaskLoader<ArrayList<WeaponListEntry>> {
         String mType;
         public WeaponArrayLoader(Context context, String type) {
             super(context);
             mType = type;
         }
 
-        public ArrayList<Weapon> loadInBackground() {
-            return DataManager.get(getContext()).queryWeaponTypeArray(mType);
+        public ArrayList<WeaponListEntry> loadInBackground() {
+            return DataManager.get(getContext()).queryWeaponTreeArray(mType);
         }
     }
 
+    @Override
+    public void onPause() {
+        savedState = new Bundle();
+        savedState.putIntegerArrayList(GROUPS_KEY, mAdapter.saveGroups());
+        super.onPause();
+    }
 
-	//protected abstract CursorAdapter getDetailAdapter();
-
-	//protected abstract Weapon getDetailWeapon(int position);
-
-	//protected abstract Fragment getThisFragment();
+    @Override
+    public void onResume() {
+        if (savedState != null) {
+            List<Integer> groups = savedState.getIntegerArrayList(GROUPS_KEY);
+            mAdapter.restoreGroups(groups);
+        }
+        super.onResume();
+    }
 }

--- a/app/src/main/java/com/daviancorp/android/ui/list/WeaponListFragment.java
+++ b/app/src/main/java/com/daviancorp/android/ui/list/WeaponListFragment.java
@@ -130,26 +130,9 @@ public abstract class WeaponListFragment extends Fragment implements
     @Override
     public void onLoadFinished(Loader<ArrayList<WeaponListEntry>> loader,
                                ArrayList<WeaponListEntry> weapons) {
-        // TODO: Use a filter interface/object/etc to perform filtering
-
-        ArrayList<WeaponListEntry> filteredWeapons = weapons;
-
-        if (isFilterFinal) {
-            mAdapter.setPaddingEnabled(false);
-            filteredWeapons = new ArrayList<>();
-            for (WeaponListEntry entry : weapons) {
-                if (entry.weapon.getWFinal() == 1) {
-                    filteredWeapons.add(entry);
-                }
-            }
-        }
-
-        // If filter final is set, disable weapon padding
-        mAdapter.setPaddingEnabled(!isFilterFinal);
-
         mRecyclerView.setAdapter(mAdapter);
         mAdapter.clear();
-        mAdapter.addAll(filteredWeapons);
+        mAdapter.addAll(weapons);
     }
 
     @Override
@@ -166,18 +149,24 @@ public abstract class WeaponListFragment extends Fragment implements
         if (args != null) {
             mType = args.getString(ARG_TYPE);
         }
-        return new WeaponArrayLoader(getActivity().getApplicationContext(), mType);
+        return new WeaponArrayLoader(getActivity().getApplicationContext(), mType, isFilterFinal);
     }
 
     static class WeaponArrayLoader extends AsyncTaskLoader<ArrayList<WeaponListEntry>> {
         String mType;
-        public WeaponArrayLoader(Context context, String type) {
+        boolean mFinalOnly;
+        public WeaponArrayLoader(Context context, String type, boolean finalOnly) {
             super(context);
             mType = type;
+            mFinalOnly = finalOnly;
         }
 
         public ArrayList<WeaponListEntry> loadInBackground() {
-            return DataManager.get(getContext()).queryWeaponTreeArray(mType);
+            if (mFinalOnly) {
+                return DataManager.get(getContext()).queryWeaponTreeArrayFinal(mType);
+            } else {
+                return DataManager.get(getContext()).queryWeaponTreeArray(mType);
+            }
         }
     }
 

--- a/app/src/main/res/menu/menu_weapon.xml
+++ b/app/src/main/res/menu/menu_weapon.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/filter_final"
+        android:showAsAction="never"
+        android:title="Final Only"
+        android:checkable="true"/>
+</menu>

--- a/app/src/main/res/menu/menu_weapon.xml
+++ b/app/src/main/res/menu/menu_weapon.xml
@@ -3,6 +3,6 @@
     <item
         android:id="@+id/filter_final"
         android:showAsAction="never"
-        android:title="Final Only"
+        android:title="@string/filter_final_option"
         android:checkable="true"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="submit">Submit</string>
 
     <string name="placeholder_unknown">Unknown</string>
+    <string name="filter_final_option">Final Only</string>
 
     <string name="dialog_message_delete">\"%s\" will be deleted.</string>
     <string name="dialog_message_delete_multi">These %d items will be deleted.</string>


### PR DESCRIPTION
Refactored weapon expandable list fragment classes to promote code reuse, and added a final only option in the menu of weapon list pages. However, the database has incorrect values for final weapons, so this cannot be used until there is a database update.

![image](https://cloud.githubusercontent.com/assets/1286721/9027426/ba584556-3922-11e5-8f93-dd5fcf913685.png)
